### PR TITLE
Minor changes; switched find_equivalent_atoms to NumPy style docstring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ venv.bak/
 .mypy_cache/
 tests/timeit_test.py
 .DS_Store
+.vscode/
+docs_out/


### PR DESCRIPTION
A small preview of the planned docstring-style change.
If you have any questions, comments, suggestions, etc. feel free to ask.

Changes to `substitution_symmetry.find_equivalent_atoms()`:
* Added [type hints](https://docs.python.org/3/library/typing.html).
* Updated docstring and switched docstring to [NumPy style](https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html#example-numpy).
* Removed a for-loop.