### PR TITLE
``uniform_idx()`` now returns the correct indices

### DIFF
--- a/examples/input.py
+++ b/examples/input.py
@@ -10,7 +10,6 @@ from CAT.logger import logger
 
 
 yaml_path = join(dirname(__file__), 'input_settings.yaml')
-# yaml_path = '/Users/basvanbeek/Downloads/juliette.yaml'
 with open(yaml_path, 'r') as file:
     arg = Settings(yaml.load(file, Loader=yaml.FullLoader))
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -23,10 +23,10 @@ def test_distribute_idx() -> None:
     out4 = distribute_idx(MOL, IDX, p=0.5, mode='cluster', start=-1)
     out5 = distribute_idx(MOL, IDX, mode='random', p=0.5)
 
-    np.testing.assert_array_equal(out1, [132, 141, 134, 137, 143, 138, 148, 133, 139, 147, 130, 125, 131])  # noqa
-    np.testing.assert_array_equal(out2, [130, 142, 140, 143, 124, 134, 139, 132, 141, 146, 125, 148, 133])  # noqa
-    np.testing.assert_array_equal(out3, [141, 134, 137, 143, 138, 148, 133, 139, 147, 130, 125, 131, 142])  # noqa
-    np.testing.assert_array_equal(out4, [131, 137, 144, 130, 142, 140, 143, 124, 134, 139, 132, 141, 146])  # noqa
+    np.testing.assert_array_equal(out1, [129, 139, 141, 144, 133, 137, 123, 148, 132, 131, 127, 145, 142])  # noqa
+    np.testing.assert_array_equal(out2, [134, 146, 144, 147, 128, 138, 143, 136, 145, 124, 129, 126, 137])  # noqa
+    np.testing.assert_array_equal(out3, [142, 135, 138, 144, 139, 123, 134, 140, 148, 131, 126, 132, 143])  # noqa
+    np.testing.assert_array_equal(out4, [132, 138, 145, 131, 143, 141, 144, 125, 135, 140, 133, 142, 147])  # noqa
     assertion.len_eq(out5, round(0.5 * len(IDX)))
     assertion.len_eq(np.intersect1d(out5, IDX), len(out5))
 


### PR DESCRIPTION
* Fixed a bug where ``uniform_idx()`` yielded the rolled, rather than unshifted, indices.

