### PR TITLE
Bug fixes

### DIFF
--- a/CAT/attachment/optimize_rotmat.py
+++ b/CAT/attachment/optimize_rotmat.py
@@ -71,7 +71,11 @@ def optimize_rotmat(mol: np.ndarray, anchor: int = 0) -> np.ndarray:
     # Create a first guess for the starting
     vec1 = xyz.mean(axis=0) - xyz[i]
     vec2 = np.array([1, 0, 0], dtype=float)
-    rotmat1 = rotation_matrix(vec1, vec2)
+    with np.errstate(invalid='raise'):
+        try:
+            rotmat1 = rotation_matrix(vec1, vec2)
+        except FloatingPointError:
+            return np.eye(3)
     xyz_new = xyz@rotmat1.T
 
     # Optimize the trial vector; return the matching rotation matrix

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -23,10 +23,10 @@ def test_distribute_idx() -> None:
     out4 = distribute_idx(MOL, IDX, p=0.5, mode='cluster', start=-1)
     out5 = distribute_idx(MOL, IDX, mode='random', p=0.5)
 
-    np.testing.assert_array_equal(out1, [129, 139, 141, 144, 133, 137, 123, 148, 132, 131, 127, 145, 142])  # noqa
-    np.testing.assert_array_equal(out2, [134, 146, 144, 147, 128, 138, 143, 136, 145, 124, 129, 126, 137])  # noqa
-    np.testing.assert_array_equal(out3, [142, 135, 138, 144, 139, 123, 134, 140, 148, 131, 126, 132, 143])  # noqa
-    np.testing.assert_array_equal(out4, [132, 138, 145, 131, 143, 141, 144, 125, 135, 140, 133, 142, 147])  # noqa
+    np.testing.assert_array_equal(out1, [134, 146, 144, 147, 128, 138, 143, 136, 145, 124, 129, 126, 137])  # noqa
+    np.testing.assert_array_equal(out2, [129, 139, 141, 144, 133, 137, 123, 148, 132, 131, 127, 145, 142])  # noqa
+    np.testing.assert_array_equal(out3, [132, 138, 145, 131, 143, 141, 144, 125, 135, 140, 133, 142, 147])  # noqa
+    np.testing.assert_array_equal(out4, [142, 135, 138, 144, 139, 123, 134, 140, 148, 131, 126, 132, 143])  # noqa
     assertion.len_eq(out5, round(0.5 * len(IDX)))
     assertion.len_eq(np.intersect1d(out5, IDX), len(out5))
 


### PR DESCRIPTION
* Return the identity (rotation) matrix if a ``FloatingPointError`` is encountered during the creation of rotation matrices. This can occur if a ligand consists of a single atom.
* Fixed a bug in the parsing of the mode parameter of ``distribute_idx()``; ``"uniform"`` and ``"cluster"`` will now correctly link to ``np.argmax`` and ``np.argmin`` instead of the other way around.