### PR TITLE
Added the "distance_upper_bound" and "k" keywords for the MD-ASA procedure

### DIFF
--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -60,6 +60,7 @@ from operator import __index__
 from typing import Dict, Collection, Callable, Any, Optional, TypeVar
 from collections import abc
 
+import numpy as np
 from schema import Or, And, Use, Schema
 from schema import Optional as Optional_
 
@@ -834,6 +835,15 @@ asa_schema: Schema = Schema({
     # Delete files after the calculations are finished
     Optional_('keep_files', default=True):
         And(bool, error='optional.qd.activation_strain.keep_files expects a boolean'),
+
+    Optional_('distance_upper_bound', default=np.inf):
+        Or(
+            And(str, lambda n: 'inf' in n.lower, Use(lambda n: np.inf)),
+            And(val_float, lambda n: float(n) > 0, Use(float))
+        ),
+
+    Optional_('k', default=20):
+        And(val_int, lambda n: int(n) > 0, Use(int)),
 
     # The job type for constructing the COSMO surface
     Optional_('job1', default=None):

--- a/docs/11_md_asa.rst
+++ b/docs/11_md_asa.rst
@@ -189,6 +189,9 @@ activation_strain
                     scale_elstat: 0.0
                     scale_lj: 1.0
 
+                    distance_upper_bound: "inf"
+                    k: 20
+
                     job1: cp2kjob
                     s1: ...
 
@@ -249,6 +252,27 @@ activation_strain
         Scaling factor to apply to all 1,4-nonbonded Lennard-Jones interactions.
 
         Serves the same purpose as the cp2k VDW_SCALE14_ keyword.
+
+
+    .. attribute:: optional.qd.activation_strain.distance_upper_bound
+
+        :Parameter:     * **Type** - :class:`float` or :class:`str`
+                        * **Default value** – ``"inf"``
+
+        Consider only atom-pairs within this distance for calculating inter-ligand interactions.
+
+        Units are in Angstrom.
+        Using ``"inf"`` will default to the full, untruncated, distance matrix.
+
+
+    .. attribute:: optional.qd.activation_strain.k
+
+        :Parameter:     * **Type** - :class:`int`
+                        * **Default value** – ``20``
+
+        The (maximum) number of to-be considered distances per atom.
+
+        Only relevant when :attr:`distance_upper_bound != "inf"<optional.qd.activation_strain.distance_upper_bound>`.
 
 
     .. attribute:: optional.qd.activation_strain.job1


### PR DESCRIPTION
* Added the "distance_upper_bound" and "k" keywords for the MD-ASA procedure (see https://github.com/nlesc-nano/nano-CAT/pull/28).