### PR TITLE
Issue a warning when ligand atoms are too close when constructing QDs

### DIFF
--- a/CAT/attachment/ligand_attach.py
+++ b/CAT/attachment/ligand_attach.py
@@ -50,7 +50,7 @@ from scipy.spatial import cKDTree
 
 from scm.plams import (Molecule, Atom, Settings)
 
-from ..mol_utils import (merge_mol, get_index, round_coords)
+from ..mol_utils import (get_index, round_coords)
 from ..workflows import WorkFlow, HDF5_INDEX, MOL, OPT
 from ..settings_dataframe import SettingsDataFrame
 from ..data_handling.mol_to_file import mol_to_file
@@ -591,7 +591,8 @@ def array_to_qd(mol: Molecule, xyz_array: np.ndarray,
     if mol_out is None:
         return mol_list
     else:
-        mol_out.merge_mol(mol_list)
+        for m in mol_list:
+            mol_out.add_molecule(m)
         return None
 
 

--- a/CAT/data_handling/__init__.py
+++ b/CAT/data_handling/__init__.py
@@ -6,9 +6,13 @@ Modules related to the importing, exporting and general handling of data.
 
 """
 
-from .mol_import import (read_mol, set_mol_prop)
+from .mol_import import read_mol, set_mol_prop
+from .warn_map import WARN_MAP
+from .mol_to_file import mol_to_file
 
 
 __all__ = [
     'read_mol', 'set_mol_prop',
+    'WARN_MAP',
+    'mol_to_file'
 ]

--- a/CAT/data_handling/warn_map.py
+++ b/CAT/data_handling/warn_map.py
@@ -1,0 +1,27 @@
+import warnings
+from types import MappingProxyType
+from typing import Mapping, Callable, NoReturn, Union
+
+__all__ = ['WARN_MAP']
+
+
+def _warn(exc: Exception) -> None:
+    """Perform a warning using **exc**."""
+    warnings.warn(str(exc), category=RuntimeWarning, stacklevel=2)
+
+
+def _raise(exc: Exception) -> NoReturn:
+    """Raise **exc**."""
+    raise exc
+
+
+def _ignore(exc: Exception) -> None:
+    """Do nothing."""
+    return None
+
+
+WARN_MAP: Mapping[str, Callable[[Exception], Union[NoReturn, None]]] = MappingProxyType({
+    'raise': _raise,
+    'warn': _warn,
+    'ignore': _ignore
+})

--- a/CAT/mol_utils.py
+++ b/CAT/mol_utils.py
@@ -11,7 +11,6 @@ Index
     from_mol_other
     from_rdmol
     get_index
-    merge_mol
     separate_mod
     to_atnum
     to_symbol
@@ -24,7 +23,6 @@ API
 .. automethod:: from_mol_other
 .. automethod:: from_rdmol
 .. automethod:: get_index
-.. automethod:: merge_mol
 .. automethod:: separate_mod
 .. autofunction:: to_atnum
 .. autofunction:: to_symbol
@@ -141,33 +139,6 @@ def get_index(self, value: Union[Atom, Bond]) -> Union[int, Tuple[int, int]]:
 
     err = "item excepts an instance of 'Atom' or 'Bond'; observed type: '{}'"
     raise TypeError(err.format(value.__class__.__name__))
-
-
-@add_to_class(Molecule)
-def merge_mol(self, mol_list: Union[Molecule, Iterable[Molecule]]) -> None:
-    """Merge two or more molecules into a single molecule.
-
-    No new copies of atoms/bonds are created, all atoms/bonds are moved from
-    mol_list to plams_mol.
-    Performs an inplace update of this instance.
-
-    Parameters
-    ----------
-    mol_list : |plams.Molecule|_ or |list|_ [|plams.Molecule|_]
-        A molecule or list of molecules.
-
-    """
-    if isinstance(mol_list, Molecule):
-        mol_list = (mol_list,)
-
-    for mol in mol_list:
-        for atom in mol.atoms:
-            atom.mol = self
-        for bond in mol.bonds:
-            bond.mol = self
-        self.properties.soft_update(mol.properties)
-        self.atoms += mol.atoms
-        self.bonds += mol.bonds
 
 
 @add_to_class(Molecule)

--- a/tests/test_mol_utils.py
+++ b/tests/test_mol_utils.py
@@ -8,7 +8,7 @@ import scm.plams.interfaces.molecule.rdkit as molkit
 from assertionlib import assertion
 
 from CAT.mol_utils import (
-    from_mol_other, from_rdmol, get_index, merge_mol, separate_mod,
+    from_mol_other, from_rdmol, get_index, separate_mod,
     to_atnum, to_symbol, adf_connectivity, fix_carboxyl, fix_h
 )
 
@@ -53,22 +53,6 @@ def test_get_index() -> None:
     for bond, j in zip(MOL.bonds, ref):
         i = MOL.get_index(bond)
         assertion.eq(i, j)
-
-
-def test_merge_mol() -> None:
-    """Test :meth:`Molecule.merge_mol`."""
-    mol = MOL.copy()
-    mol_list = [mol.copy() for _ in range(10)]
-    atom_list = list(chain.from_iterable(mol_list)) + mol.atoms
-    bond_list = list(chain.from_iterable(m.bonds for m in mol_list)) + mol.bonds
-    mol.merge_mol(mol_list)
-
-    assertion.eq(len(mol.atoms), len(atom_list))
-    assertion.eq(len(mol.bonds), len(bond_list))
-    for at in mol.atoms:
-        assertion.contains(atom_list, at)
-    for bond in mol.bonds:
-        assertion.contains(bond_list, bond)
 
 
 def test_separate_mod() -> None:


### PR DESCRIPTION
* Issue a warning when ligand atoms are too close (<1 Angstrom) when constructing quantum dots.
* Improved warning handling.
* Removed a number of redundant functions.