### PR TITLE
Re-enable Python 3.6 tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
                 version: [3.6, 3.7, 3.8]
 
         steps:
-            - name: Checkout ${{ GITHUB_WORKSPACE }}
+            - name: Checkout $GITHUB_REF
               uses: actions/checkout@v2
 
             - name: Set up Conda with Python ${{ matrix.version }} on ${{ matrix.os }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,10 +17,11 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest]
-                version: [3.7, 3.8]
+                version: [3.6, 3.7, 3.8]
 
         steps:
-            - uses: actions/checkout@v2
+            - name: Checkout ${{ GITHUB_WORKSPACE }}
+              uses: actions/checkout@v2
 
             - name: Set up Conda with Python ${{ matrix.version }} on ${{ matrix.os }}
               uses: s-weigand/setup-conda@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,8 @@ jobs:
                 version: [3.6, 3.7, 3.8]
 
         steps:
-            - uses: actions/checkout@v2
+            - name: Checkout ${{ GITHUB_WORKSPACE }}
+              uses: actions/checkout@v2
 
             - name: Set up Conda with Python ${{ matrix.version }} on ${{ matrix.os }}
               uses: s-weigand/setup-conda@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,8 +20,7 @@ jobs:
                 version: [3.6, 3.7, 3.8]
 
         steps:
-            - name: Checkout $GITHUB_REF
-              uses: actions/checkout@v2
+            - uses: actions/checkout@v2
 
             - name: Set up Conda with Python ${{ matrix.version }} on ${{ matrix.os }}
               uses: s-weigand/setup-conda@v1

--- a/CAT/recipes.py
+++ b/CAT/recipes.py
@@ -4,10 +4,10 @@ Examples
 --------
 .. code:: python
 
-    >>> from CAT.recipes import bulk_workflow
-    >>> from CAT.recipes import replace_surface
-    >>> from CAT.recipes import dissociate_surface, row_accumulator
-    >>> from CAT.recipes import coordination_number
+    >>> from CAT.recipes import bulk_workflow  # doctest: +SKIP
+    >>> from CAT.recipes import replace_surface  # doctest: +SKIP
+    >>> from CAT.recipes import dissociate_surface, row_accumulator  # doctest: +SKIP
+    >>> from CAT.recipes import coordination_number  # doctest: +SKIP
     >>> from CAT.recipes import add_ligands, export_dyes, sa_scores
     ...
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 * Fixed an issue where certain `AMSJobs` would have duplicate keys.
 * Fixed an issue where certain ligands weren't exported when constructing
   multi-ligand quantum dots (see https://github.com/nlesc-nano/CAT/issues/115).
+* Re-enabled tests for Python 3.6 (see https://github.com/nlesc-nano/CAT/issues/125).
 
 
 0.9.3

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
+import sys
 
 from setuptools import setup
 
@@ -17,8 +18,6 @@ with open('README.rst', encoding='utf-8') as readme_file:
 docs_require = [
     'sphinx>=2.1',
     'sphinx_rtd_theme',
-    'data-CAT@git+https://github.com/nlesc-nano/data-CAT@devel',
-    'nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@devel'
 ]
 
 tests_require = [
@@ -30,10 +29,12 @@ tests_require = [
     'pydocstyle>=5.0.0',
     'pytest-pydocstyle>=2.1',
     'pytest-mock',
-    'data-CAT@git+https://github.com/nlesc-nano/data-CAT@devel',
-    'nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@devel; python_version>"3.6"',
-    'auto-fox@git+https://github.com/nlesc-nano/auto-FOX@devel; python_version>"3.6"'
+    'data-CAT@git+https://github.com/nlesc-nano/data-CAT@devel'
 ]
+
+if sys.version_info[1] > 6:
+    docs_require.append('nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@devel')
+    docs_require.append('nano-CAT@git+https://github.com/nlesc-nano/auto-FOX@devel')
 tests_require += docs_require
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ tests_require = [
     'pytest-pydocstyle>=2.1',
     'pytest-mock',
     'data-CAT@git+https://github.com/nlesc-nano/data-CAT@devel',
-    'nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@devel',
-    'auto-fox@git+https://github.com/nlesc-nano/auto-FOX@devel'
+    'nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@devel; python_version>"3.6"',
+    'auto-fox@git+https://github.com/nlesc-nano/auto-FOX@devel; python_version>"3.6"'
 ]
 tests_require += docs_require
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ if sys.version_info[1] > 6:
     docs_require.append('nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@devel')
     docs_require.append('nano-CAT@git+https://github.com/nlesc-nano/auto-FOX@devel')
 tests_require += docs_require
+print(tests_require)
 
 setup(
     name='CAT',

--- a/tests/test_CAT.py
+++ b/tests/test_CAT.py
@@ -1,13 +1,20 @@
 """Tests for the various workflows within the CAT package."""
 
 from pathlib import Path
+from typing import Optional
 
 import yaml
 import pytest
 from scm.plams import Settings
-from nanoutils import delete_finally
+from nanoutils import delete_finally, ignore_if
 
 from CAT.base import prep
+
+try:
+    import nanoCAT
+    NANOCAT_EX: Optional[ImportError] = None
+except ImportError as ex:
+    NANOCAT_EX = ex
 
 PATH = Path('tests') / 'test_files'
 LIG_PATH = PATH / 'ligand'
@@ -16,6 +23,7 @@ DB_PATH = PATH / 'database'
 
 
 @pytest.mark.slow
+@ignore_if(NANOCAT_EX)
 @delete_finally(LIG_PATH, QD_PATH, DB_PATH)
 def test_cat() -> None:
     """Tests for the CAT package."""

--- a/tests/test_CAT.py
+++ b/tests/test_CAT.py
@@ -11,7 +11,7 @@ from nanoutils import delete_finally, ignore_if
 from CAT.base import prep
 
 try:
-    import nanoCAT
+    import nanoCAT  # noqa: F401
     NANOCAT_EX: Optional[ImportError] = None
 except ImportError as ex:
     NANOCAT_EX = ex

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -7,7 +7,7 @@ from sphinx.application import Sphinx
 from nanoutils import delete_finally, ignore_if
 
 try:
-    import nanoCAT
+    import nanoCAT  # noqa: F401
     NANOCAT_EX: Optional[ImportError] = None
 except ImportError as ex:
     NANOCAT_EX = ex

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,15 +1,23 @@
 """Test the :mod:`sphinx` documentation generation."""
 
 from os.path import join
-from sphinx.application import Sphinx
+from typing import Optional
 
-from nanoutils import delete_finally
+from sphinx.application import Sphinx
+from nanoutils import delete_finally, ignore_if
+
+try:
+    import nanoCAT
+    NANOCAT_EX: Optional[ImportError] = None
+except ImportError as ex:
+    NANOCAT_EX = ex
 
 SRCDIR = CONFDIR = 'docs'
 OUTDIR = join('tests', 'test_files', 'build')
 DOCTREEDIR = join('tests', 'test_files', 'build', 'doctrees')
 
 
+@ignore_if(NANOCAT_EX)
 @delete_finally(OUTDIR)
 def test_sphinx_build() -> None:
     """Test :meth:`sphinx.application.Sphinx.build`."""


### PR DESCRIPTION
Implementation of https://github.com/nlesc-nano/CAT/issues/125:
* Re-enabled tests for Python 3.6.