### PR TITLE
Skip the second stage optimization if the first one fails

### DIFF
--- a/CAT/attachment/ligand_opt.py
+++ b/CAT/attachment/ligand_opt.py
@@ -136,6 +136,7 @@ def _start_ligand_jobs_plams(ligand_list: Iterable[Molecule],
             optimize_ligand(ligand)
         except Exception as ex:
             logger.debug(f'{ex.__class__.__name__}: {ex}', exc_info=True)
+            continue
 
         s = Settings(settings)
         charge_func(s, int(sum(at.properties.get('charge', 0) for at in ligand)))

--- a/CAT/attachment/ligand_opt.py
+++ b/CAT/attachment/ligand_opt.py
@@ -136,12 +136,14 @@ def _start_ligand_jobs_plams(ligand_list: Iterable[Molecule],
             optimize_ligand(ligand)
         except Exception as ex:
             logger.debug(f'{ex.__class__.__name__}: {ex}', exc_info=True)
+            ligand.properties.is_opt = False
             continue
 
         s = Settings(settings)
         charge_func(s, int(sum(at.properties.get('charge', 0) for at in ligand)))
         ligand.job_geometry_opt(job, s, name='ligand_opt')
         ligand.round_coords()
+        ligand.properties.is_opt = True
     return None
 
 
@@ -152,10 +154,12 @@ def _start_ligand_jobs_uff(ligand_list: Iterable[Molecule]) -> None:
         try:
             optimize_ligand(ligand)
         except Exception as ex:
+            ligand.properties.is_opt = False
             logger.error(f'UFFGetMoleculeForceField: {ligand.properties.name} optimization '
                          'has failed')
             logger.debug(f'{ex.__class__.__name__}: {ex}', exc_info=True)
         else:
+            ligand.properties.is_opt = True
             logger.info(f'UFFGetMoleculeForceField: {ligand.properties.name} optimization '
                         'is successful')
     return None

--- a/CAT/base.py
+++ b/CAT/base.py
@@ -294,6 +294,11 @@ def prep_ligand(ligand_df: SettingsDataFrame) -> SettingsDataFrame:
     # Optimize the ligands
     if optimize:
         init_ligand_opt(ligand_df)
+
+        # Remove failed optimizations from the ligand list
+        _is_opt = (lig.properties.get('is_opt', False) for lig in ligand_df[MOL])
+        is_opt = np.fromiter(_is_opt, count=len(ligand_df), dtype=bool)
+        ligand_df = ligand_df.loc[is_opt]
     else:
         for lig in ligand_df[MOL]:
             allign_axis(lig, lig.properties.dummies)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 0.9.5
 *****
 * Fixed a bug where rdkit molecules were not properly converted into numpy arrays.
+* Only perform `optional.ligand.optimize.job2` if the preceding UFF optimization finishes without crashing.
+* Remove a ligand if its optimization fails (_i.e._ an exception is raised).
 
 
 0.9.4


### PR DESCRIPTION
* Only perform `optional.ligand.optimize.job2` if the preceding UFF optimization finishes without crashing.
* Remove a ligand if its optimization fails (_i.e._ an exception is raised).