### PR TITLE
Version bump: 0.9.6 > 0.9.7

### DIFF
--- a/CAT/__version__.py
+++ b/CAT/__version__.py
@@ -1,3 +1,3 @@
 """The **CAT** version."""
 
-__version__ = '0.9.6'
+__version__ = '0.9.7'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 0.9.6
 *****
 * Updated the documentation for https://github.com/nlesc-nano/data-CAT/pull/25.
+* Relax the pandas version requirement.
 
 
 0.9.5

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 
 
 ##############################
-Compound Attachment Tool 0.9.6
+Compound Attachment Tool 0.9.7
 ##############################
 
 **CAT** is a collection of tools designed for the construction of various chemical compounds.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ copyright = f'{_year}, {author}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the built documents.
-release = '0.9.6'  # The full version, including alpha/beta/rc tags.
+release = '0.9.7'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]
 
 


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/CAT/issues/143.