### PR TITLE
ENH: Added to option to create workdirs with thread-safe names

### DIFF
--- a/CAT/__version__.py
+++ b/CAT/__version__.py
@@ -1,3 +1,3 @@
 """The **CAT** version."""
 
-__version__ = '0.9.7'
+__version__ = '0.9.8'

--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -349,6 +349,8 @@ database_schema: Schema = Schema({
     'dirname':
         And(str, error='optional.database.dirname expects a string'),
 
+    Optional_('thread_safe', default=False): bool,
+
     Optional_('read', default=DB_NAMES):  # Attempt to pull structures from the database
         Or(
             And(None, Use(lambda n: ())),

--- a/CAT/utils.py
+++ b/CAT/utils.py
@@ -226,7 +226,11 @@ def parallel_init(path: Union[str, 'os.PathLike[str]'],
     """
     if hashing != 'input':
         raise ValueError(f"Invalid value: {hashing!r}")
+
     folder_ = f'{folder}.{threading.get_ident()}'
+    path_abs = join(path, folder_)
+    if isdir(path_abs):
+        rmtree(path_abs)
     init(path=path, folder=folder_)
 
     # Not quite thread-safe, but as long as all threads assign a single value

--- a/CAT/workflows/workflow.py
+++ b/CAT/workflows/workflow.py
@@ -15,6 +15,7 @@ API
 
 import os
 import operator
+import threading
 from shutil import rmtree
 from pathlib import Path
 from collections import abc
@@ -524,7 +525,8 @@ class WorkFlow(AbstractDataClass):
 
         # Remove the PLAMS results directories
         if not self.keep_files:
-            rmtree(Path(self.path) / self.name)
+            name = self.name if not self.thread_safe else f'{self.name}.{threading.get_ident()}'
+            rmtree(Path(self.path) / name)
 
     @classmethod
     def from_template(cls, settings: Union[Settings, SettingsDataFrame], name: str) -> 'WorkFlow':

--- a/CAT/workflows/workflow_yaml.yaml
+++ b/CAT/workflows/workflow_yaml.yaml
@@ -6,6 +6,7 @@ asa:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         md: [optional, qd, activation_strain, md]
         use_ff: [optional, qd, activation_strain, use_ff]
@@ -30,6 +31,7 @@ ligand_opt:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, ligand, dirname]
         use_ff: [optional, ligand, optimize, use_ff]
@@ -47,6 +49,7 @@ qd_attach:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, qd, dirname]
         allignment: [optional, core, allignment]
@@ -59,6 +62,7 @@ qd_opt:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, qd, dirname]
         use_ff: [optional, qd, optimize, use_ff]
@@ -77,6 +81,7 @@ crs:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, ligand, dirname]
         keep_files: [optional, ligand, crs, keep_files]
@@ -93,6 +98,7 @@ bde:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, qd, dirname]
         keep_files: [optional, qd, dissociate, keep_files]
@@ -124,6 +130,7 @@ bulkiness:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, qd, dirname]
 
@@ -135,6 +142,7 @@ multi_ligand:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, qd, dirname]
         mol_format: [optional, database, mol_format]
@@ -161,6 +169,7 @@ cdft:
         read: [optional, database, read]
         write: [optional, database, write]
         overwrite: [optional, database, overwrite]
+        thread_safe: [optional, database, thread_safe]
 
         path: [optional, ligand, dirname]
         keep_files: [optional, ligand, cdft, keep_files]

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 
 
 ##############################
-Compound Attachment Tool 0.9.7
+Compound Attachment Tool 0.9.8
 ##############################
 
 **CAT** is a collection of tools designed for the construction of various chemical compounds.

--- a/docs/1_get_started.rst
+++ b/docs/1_get_started.rst
@@ -61,6 +61,7 @@ Verbose default Settings
             read: True
             write: True
             overwrite: False
+            thread_safe: False
             mol_format: (pdb, xyz)
             mongodb: False
 
@@ -105,6 +106,7 @@ Maximum verbose default Settings
             read: (core, ligand, qd)
             write: (core, ligand, qd)
             overwrite: False
+            thread_safe: False
             mol_format: (pdb, xyz)
             mongodb: False
 

--- a/docs/4_optional.rst
+++ b/docs/4_optional.rst
@@ -20,6 +20,7 @@ Option                                    Description
 :attr:`optional.database.read`            Attempt to read results from the database before starting calculations.
 :attr:`optional.database.write`           Export results to the database.
 :attr:`optional.database.overwrite`       Allow previous results in the database to be overwritten.
+:attr:`optional.database.thread_safe`     Ensure that the created workdir has a thread-safe name.
 :attr:`optional.database.mol_format`      The file format(s) for exporting moleculair structures.
 :attr:`optional.database.mongodb`         Options related to the MongoDB format.
 
@@ -55,6 +56,7 @@ Default Settings
             read: True
             write: True
             overwrite: False
+            thread_safe: False
             mol_format: (pdb, xyz)
             mongodb: False
 
@@ -182,6 +184,16 @@ Database
         that structures written for a specific subset.
 
         See :attr:`optional.database.read` for a similar relevant example.
+
+
+    .. attribute:: optional.database.thread_safe
+
+        :Parameter:     * **Type** - :class:`bool`
+                        * **Default value** - ``False``
+
+        Ensure that the created workdir has a thread-safe name.
+
+        Note that this disables the restarting of partially completed jobs.
 
 
     .. attribute:: optional.database.mol_format

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ copyright = f'{_year}, {author}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the built documents.
-release = '0.9.7'  # The full version, including alpha/beta/rc tags.
+release = '0.9.8'  # The full version, including alpha/beta/rc tags.
 version = release.rsplit('.', maxsplit=1)[0]
 
 

--- a/tests/test_files/input4.yaml
+++ b/tests/test_files/input4.yaml
@@ -1,0 +1,34 @@
+path: tests/test_files
+
+input_cores:
+    - Cd68Se55.xyz:
+        guess_bonds: False
+
+input_ligands:
+    - CO
+    - CCO
+
+optional:
+    database:
+        dirname: database
+        read: True
+        write: True
+        overwrite: False
+        thread_safe: True
+        mol_format: [pdb]
+        mongodb: False
+
+    core:
+        dirname: core
+        dummy: Cl
+
+    ligand:
+        dirname: ligand
+        optimize: True
+        split: True
+        cosmo-rs: False
+
+    qd:
+        dirname: QD
+        optimize: False
+        dissociate: False

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -89,9 +89,9 @@ def test_database_schema() -> None:
         'read': ('core', 'ligand', 'qd'),
         'write': ('core', 'ligand', 'qd'),
         'overwrite': (),
+        'thread_safe': False,
         'mongodb': {},
         'mol_format': ('pdb', 'xyz')
-
     }
 
     assertion.eq(database_schema.validate(db_dict), ref)

--- a/tests/test_thread_safe.py
+++ b/tests/test_thread_safe.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import yaml
+
+from nanoutils import delete_finally
+from scm.plams import Settings
+from CAT.base import prep
+
+PATH = Path('tests') / 'test_files'
+LIG_PATH = PATH / 'ligand'
+QD_PATH = PATH / 'qd'
+DB_PATH = PATH / 'database'
+
+
+@delete_finally(LIG_PATH, QD_PATH, DB_PATH)
+def test_thread_safe() -> None:
+    """Tests for the ``optional.database.thread_safe`` option."""
+    yaml_path = PATH / 'input4.yaml'
+    with open(yaml_path, 'r') as f:
+        arg = Settings(yaml.load(f, Loader=yaml.FullLoader))
+
+    arg.path = PATH
+    prep(arg)

--- a/tests/test_validate_input.py
+++ b/tests/test_validate_input.py
@@ -44,6 +44,7 @@ def test_validate_input() -> None:
     ref.database.overwrite = ()
     ref.database.read = ('core', 'ligand', 'qd')
     ref.database.write = ('core', 'ligand', 'qd')
+    ref.database.thread_safe = False
     ref.database.db = Database(ref.database.dirname, **ref.database.mongodb)
 
     ref.ligand['cosmo-rs'] = False


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/CAT/issues/149.

This pull request adds the `optional.database.thread_safe` keyword, which can be set to `True` to create PLAMS workdirs with thread-safe names.