### PR TITLE
Forcefully set the matplotlib logging level to `INFO`

### DIFF
--- a/CAT/__init__.py
+++ b/CAT/__init__.py
@@ -1,5 +1,10 @@
 """**CAT**: A collection of tools designed for the construction of various chemical compounds."""  # noqa: E501
 
+import logging
+_mpl_logger = logging.getLogger('matplotlib')
+_mpl_logger.setLevel(logging.INFO)
+del _mpl_logger, logging
+
 from nanoutils import VersionInfo
 
 from .__version__ import __version__

--- a/CAT/__init__.py
+++ b/CAT/__init__.py
@@ -1,5 +1,7 @@
 """**CAT**: A collection of tools designed for the construction of various chemical compounds."""  # noqa: E501
 
+# flake8: noqa: E402
+
 import logging
 _mpl_logger = logging.getLogger('matplotlib')
 _mpl_logger.setLevel(logging.INFO)


### PR DESCRIPTION
For some reason the `matplotlib` logger is going bananas.
Change its level from `DEBUG` (default) to `INFO` in order to silence it.