### PR TITLE
DOC: Fix the readthedocs failure

### DIFF
--- a/.environment.yaml
+++ b/.environment.yaml
@@ -5,6 +5,6 @@ channels:
 
 dependencies:
     - pip
-    - python
+    - python=3.8
     - h5py
     - rdkit

--- a/.environment.yaml
+++ b/.environment.yaml
@@ -8,3 +8,6 @@ dependencies:
     - python=3.8
     - h5py
     - rdkit
+
+    - pip:
+        - data-CAT@git+https://github.com/nlesc-nano/data-CAT@master

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,7 +20,5 @@ python:
     install:
         - method: pip
           path: .
-        - method: pip
-          path: .
           extra_requirements:
             - doc

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,5 +20,3 @@ python:
     install:
         - method: pip
           path: .
-          extra_requirements:
-            - doc_rtd

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,4 +21,4 @@ python:
         - method: pip
           path: .
           extra_requirements:
-            - doc
+            - doc_rtd

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ with open('README.rst', encoding='utf-8') as readme_file:
 
 docs_require = [
     'sphinx>=2.4,!=3.1',
-    'sphinx_rtd_theme~=0.5.0',
+    'sphinx_rtd_theme',
+    'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master'
+]
+
+docs_require_rtd = [
     'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master'
 ]
 
@@ -123,6 +127,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         'test': tests_require,
-        'doc': docs_require
+        'doc': docs_require,
+        'doc_rtd': docs_require_rtd,
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ with open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 docs_require = [
-    'sphinx>=2.4,<3.1',
-    'sphinx_rtd_theme',
+    'sphinx>=2.4,!=3.1',
+    'sphinx_rtd_theme~=0.5.0',
     'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,6 @@ docs_require = [
     'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master'
 ]
 
-docs_require_rtd = [
-    'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master'
-]
-
 tests_require = [
     'pytest>=5.4.0',
     'pytest-cov',
@@ -128,6 +124,5 @@ setup(
     extras_require={
         'test': tests_require,
         'doc': docs_require,
-        'doc_rtd': docs_require_rtd,
     }
 )


### PR DESCRIPTION
<details>

```
Read the Docs build information
Build id: 12198155
Project: cat
Version: latest
Commit: 3b8523f78ba179f3260d51b43bc066f3eef70d90
Date: 2020-10-27T13:15:51.255311Z
State: finished
Success: False


[rtd-command-info] start-time: 2020-10-27T13:15:55.244296Z, end-time: 2020-10-27T13:15:58.040923Z, duration: 2, exit-code: 0
git clone --no-single-branch --depth 50 https://github.com/nlesc-nano/CAT.git .
Cloning into '.'...

[rtd-command-info] start-time: 2020-10-27T13:15:58.498907Z, end-time: 2020-10-27T13:15:58.621371Z, duration: 0, exit-code: 0
git checkout --force origin/master
Note: checking out 'origin/master'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 3b8523f TST: Enable windows tests  (#158)

[rtd-command-info] start-time: 2020-10-27T13:15:58.909210Z, end-time: 2020-10-27T13:15:59.008353Z, duration: 0, exit-code: 0
git clean -d -f -f


[rtd-command-info] start-time: 2020-10-27T13:16:02.572778Z, end-time: 2020-10-27T13:18:59.677881Z, duration: 177, exit-code: 0
conda env create --quiet --name latest --file .environment.yaml
Collecting package metadata: ...working... done
Solving environment: ...working... done
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done

[rtd-command-info] start-time: 2020-10-27T13:18:59.933331Z, end-time: 2020-10-27T13:21:25.197821Z, duration: 145, exit-code: 0
conda install --yes --quiet --name latest mock pillow sphinx sphinx_rtd_theme
Collecting package metadata: ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest

  added / updated specs:
    - mock
    - pillow
    - sphinx
    - sphinx_rtd_theme


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    alabaster-0.7.12           |             py_0          16 KB
    babel-2.8.0                |             py_0         6.0 MB
    blas-1.0                   |         openblas          48 KB
    boost-1.57.0               |                4         9.7 MB
    brotlipy-0.7.0             |py38h7b6447c_1000         349 KB
    ca-certificates-2020.10.14 |                0         128 KB
    certifi-2020.6.20          |           py38_0         160 KB
    cffi-1.14.0                |   py38h2e261b9_0         228 KB
    chardet-3.0.4              |        py38_1003         170 KB
    cryptography-3.1.1         |   py38h1ba5d50_0         618 KB
    docutils-0.16              |           py38_1         742 KB
    h5py-2.10.0                |   py38hd6299e0_1         1.1 MB
    idna-2.10                  |             py_0          56 KB
    imagesize-1.2.0            |             py_0          10 KB
    jinja2-2.11.2              |             py_0          97 KB
    markupsafe-1.1.1           |   py38h7b6447c_0          34 KB
    mock-4.0.2                 |             py_0          31 KB
    numpy-1.19.2               |   py38h6163131_0          21 KB
    numpy-base-1.19.2          |   py38h75fe3a5_0         5.3 MB
    openssl-1.1.1h             |       h7b6447c_0         3.8 MB
    packaging-20.4             |             py_0          35 KB
    pandas-1.1.3               |   py38he6710b0_0        10.9 MB
    pillow-8.0.0               |   py38h9a89aac_0         680 KB
    pycairo-1.19.1             |   py38h2a1e443_0          77 KB
    pycparser-2.20             |             py_2          94 KB
    pygments-2.7.1             |             py_0         704 KB
    pyopenssl-19.1.0           |             py_1          47 KB
    pyparsing-2.4.7            |             py_0          64 KB
    pysocks-1.7.1              |           py38_0          27 KB
    python-3.8.2               |       hcf32534_0        57.8 MB
    requests-2.24.0            |             py_0          54 KB
    setuptools-50.3.0          |   py38hb0f4dca_1         902 KB
    snowballstemmer-2.0.0      |             py_0          58 KB
    sphinx-3.2.1               |             py_0         1.4 MB
    sphinx_rtd_theme-0.4.3     |             py_0         5.1 MB
    sphinxcontrib-applehelp-1.0.2|             py_0          30 KB
    sphinxcontrib-devhelp-1.0.2|             py_0          24 KB
    sphinxcontrib-htmlhelp-1.0.3|             py_0          29 KB
    sphinxcontrib-jsmath-1.0.1 |             py_0           8 KB
    sphinxcontrib-qthelp-1.0.3 |             py_0          26 KB
    sphinxcontrib-serializinghtml-1.1.4|             py_0          25 KB
    urllib3-1.25.11            |             py_0          93 KB
    ------------------------------------------------------------
                                           Total:       106.7 MB

The following NEW packages will be INSTALLED:

  alabaster          pkgs/main/noarch::alabaster-0.7.12-py_0
  babel              pkgs/main/noarch::babel-2.8.0-py_0
  blas               pkgs/free/linux-64::blas-1.0-openblas
  brotlipy           pkgs/main/linux-64::brotlipy-0.7.0-py38h7b6447c_1000
  cffi               pkgs/main/linux-64::cffi-1.14.0-py38h2e261b9_0
  chardet            pkgs/main/linux-64::chardet-3.0.4-py38_1003
  cryptography       pkgs/main/linux-64::cryptography-3.1.1-py38h1ba5d50_0
  docutils           pkgs/main/linux-64::docutils-0.16-py38_1
  idna               pkgs/main/noarch::idna-2.10-py_0
  imagesize          pkgs/main/noarch::imagesize-1.2.0-py_0
  jinja2             pkgs/main/noarch::jinja2-2.11.2-py_0
  markupsafe         pkgs/main/linux-64::markupsafe-1.1.1-py38h7b6447c_0
  mock               pkgs/main/noarch::mock-4.0.2-py_0
  numpy-base         pkgs/main/linux-64::numpy-base-1.19.2-py38h75fe3a5_0
  packaging          pkgs/main/noarch::packaging-20.4-py_0
  pycparser          pkgs/main/noarch::pycparser-2.20-py_2
  pygments           pkgs/main/noarch::pygments-2.7.1-py_0
  pyopenssl          pkgs/main/noarch::pyopenssl-19.1.0-py_1
  pyparsing          pkgs/main/noarch::pyparsing-2.4.7-py_0
  pysocks            pkgs/main/linux-64::pysocks-1.7.1-py38_0
  requests           pkgs/main/noarch::requests-2.24.0-py_0
  snowballstemmer    pkgs/main/noarch::snowballstemmer-2.0.0-py_0
  sphinx             pkgs/main/noarch::sphinx-3.2.1-py_0
  sphinx_rtd_theme   pkgs/main/noarch::sphinx_rtd_theme-0.4.3-py_0
  sphinxcontrib-app~ pkgs/main/noarch::sphinxcontrib-applehelp-1.0.2-py_0
  sphinxcontrib-dev~ pkgs/main/noarch::sphinxcontrib-devhelp-1.0.2-py_0
  sphinxcontrib-htm~ pkgs/main/noarch::sphinxcontrib-htmlhelp-1.0.3-py_0
  sphinxcontrib-jsm~ pkgs/main/noarch::sphinxcontrib-jsmath-1.0.1-py_0
  sphinxcontrib-qth~ pkgs/main/noarch::sphinxcontrib-qthelp-1.0.3-py_0
  sphinxcontrib-ser~ pkgs/main/noarch::sphinxcontrib-serializinghtml-1.1.4-py_0
  urllib3            pkgs/main/noarch::urllib3-1.25.11-py_0

The following packages will be REMOVED:

  python_abi-3.9-1_cp39
  rdkit-2020.09.1-py39h54e287e_0

The following packages will be UPDATED:

  ca-certificates    conda-forge::ca-certificates-2020.6.2~ --> pkgs/main::ca-certificates-2020.10.14-0
  setuptools         conda-forge::setuptools-49.6.0-py39h0~ --> pkgs/main::setuptools-50.3.0-py38hb0f4dca_1

The following packages will be SUPERSEDED by a higher-priority channel:

  boost              conda-forge::boost-1.74.0-py39ha90915~ --> pkgs/free::boost-1.57.0-4
  certifi            conda-forge::certifi-2020.6.20-py39h0~ --> pkgs/main::certifi-2020.6.20-py38_0
  h5py               conda-forge::h5py-2.10.0-nompi_py39h8~ --> pkgs/main::h5py-2.10.0-py38hd6299e0_1
  numpy              conda-forge::numpy-1.19.2-py39h2bb7b6~ --> pkgs/main::numpy-1.19.2-py38h6163131_0
  openssl            conda-forge::openssl-1.1.1h-h516909a_0 --> pkgs/main::openssl-1.1.1h-h7b6447c_0
  pandas             conda-forge::pandas-1.1.3-py39h1670d0~ --> pkgs/main::pandas-1.1.3-py38he6710b0_0
  pillow             conda-forge::pillow-8.0.1-py39h6f3857~ --> pkgs/main::pillow-8.0.0-py38h9a89aac_0
  pycairo            conda-forge::pycairo-1.20.0-py39h0862~ --> pkgs/main::pycairo-1.19.1-py38h2a1e443_0
  python             conda-forge::python-3.9.0-h2a148a8_4_~ --> pkgs/main::python-3.8.2-hcf32534_0


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done

[rtd-command-info] start-time: 2020-10-27T13:21:25.475917Z, end-time: 2020-10-27T13:21:28.898320Z, duration: 3, exit-code: 0
/home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/bin/python -m pip install -U --no-cache-dir --use-feature 2020-resolver recommonmark readthedocs-sphinx-ext
Collecting recommonmark
  Downloading recommonmark-0.6.0-py2.py3-none-any.whl (10 kB)
Requirement already satisfied: docutils>=0.11 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from recommonmark) (0.16)
Requirement already satisfied: sphinx>=1.3.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from recommonmark) (3.2.1)
Collecting readthedocs-sphinx-ext
  Downloading readthedocs_sphinx_ext-2.1.1-py2.py3-none-any.whl (13 kB)
Requirement already satisfied: Jinja2>=2.9 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from readthedocs-sphinx-ext) (2.11.2)
Requirement already satisfied: requests in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from readthedocs-sphinx-ext) (2.24.0)
Requirement already satisfied: sphinxcontrib-applehelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.0.2)
Requirement already satisfied: babel>=1.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (2.8.0)
Requirement already satisfied: sphinxcontrib-htmlhelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.0.3)
Requirement already satisfied: sphinxcontrib-qthelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.0.3)
Requirement already satisfied: Pygments>=2.0 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (2.7.1)
Requirement already satisfied: sphinxcontrib-serializinghtml in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.1.4)
Requirement already satisfied: sphinxcontrib-devhelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.0.2)
Requirement already satisfied: alabaster<0.8,>=0.7 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (0.7.12)
Requirement already satisfied: requests in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from readthedocs-sphinx-ext) (2.24.0)
Requirement already satisfied: imagesize in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.2.0)
Requirement already satisfied: packaging in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (20.4)
Requirement already satisfied: docutils>=0.11 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from recommonmark) (0.16)
Requirement already satisfied: setuptools in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (50.3.0.post20201006)
Requirement already satisfied: snowballstemmer>=1.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (2.0.0)
Requirement already satisfied: sphinxcontrib-jsmath in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx>=1.3.1->recommonmark) (1.0.1)
Requirement already satisfied: Jinja2>=2.9 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from readthedocs-sphinx-ext) (2.11.2)
Collecting commonmark>=0.8.1
  Downloading commonmark-0.9.1-py2.py3-none-any.whl (51 kB)
Requirement already satisfied: MarkupSafe>=0.23 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from Jinja2>=2.9->readthedocs-sphinx-ext) (1.1.1)
Requirement already satisfied: idna<3,>=2.5 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from requests->readthedocs-sphinx-ext) (2.10)
Requirement already satisfied: certifi>=2017.4.17 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from requests->readthedocs-sphinx-ext) (2020.6.20)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from requests->readthedocs-sphinx-ext) (1.25.11)
Requirement already satisfied: chardet<4,>=3.0.2 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from requests->readthedocs-sphinx-ext) (3.0.4)
Requirement already satisfied: pytz>=2015.7 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from babel>=1.3->sphinx>=1.3.1->recommonmark) (2020.1)
Requirement already satisfied: six in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from packaging->sphinx>=1.3.1->recommonmark) (1.15.0)
Requirement already satisfied: pyparsing>=2.0.2 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from packaging->sphinx>=1.3.1->recommonmark) (2.4.7)
Installing collected packages: commonmark, recommonmark, readthedocs-sphinx-ext
Successfully installed commonmark-0.9.1 readthedocs-sphinx-ext-2.1.1 recommonmark-0.6.0

[rtd-command-info] start-time: 2020-10-27T13:21:29.137571Z, end-time: 2020-10-27T13:21:58.995320Z, duration: 29, exit-code: 0
/home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir --use-feature 2020-resolver .
Processing /home/docs/checkouts/readthedocs.org/user_builds/cat/checkouts/latest
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: pandas in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.3)
Collecting Nano-Utils>=0.4.3
  Downloading Nano_Utils-1.1.2-py3-none-any.whl (27 kB)
Collecting scipy
  Downloading scipy-1.5.3-cp38-cp38-manylinux1_x86_64.whl (25.8 MB)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: python-dateutil>=2.7.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from pandas->CAT==0.9.10) (2.8.1)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: pytz>=2017.2 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from pandas->CAT==0.9.10) (2020.1)
Collecting pyyaml>=5.1
  Downloading PyYAML-5.3.1.tar.gz (269 kB)
Collecting schema
  Downloading schema-0.7.2-py2.py3-none-any.whl (16 kB)
Collecting AssertionLib>=2.2.3
  Downloading AssertionLib-3.1.3-py3-none-any.whl (32 kB)
Collecting plams@ git+https://github.com/SCM-NV/PLAMS@a5696ce62c09153a9fa67b2b03a750913e1d0924
  Cloning https://github.com/SCM-NV/PLAMS (to revision a5696ce62c09153a9fa67b2b03a750913e1d0924) to /tmp/pip-install-hz0w3de3/plams_159dd0cba7214f1dafefdfc31af30738
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Collecting qmflows@ git+https://github.com/SCM-NV/qmflows@master
  Cloning https://github.com/SCM-NV/qmflows (to revision master) to /tmp/pip-install-hz0w3de3/qmflows_eedd47800b7e48439f8a2caa896e5bda
Requirement already satisfied: h5py in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (2.10.0)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: pandas in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.3)
Requirement already satisfied: pyparsing in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (2.4.7)
Requirement already satisfied: six>=1.5 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from python-dateutil>=2.7.3->pandas->CAT==0.9.10) (1.15.0)
Collecting contextlib2>=0.5.5
  Downloading contextlib2-0.6.0.post1-py2.py3-none-any.whl (9.8 kB)
Collecting dill>=0.2.4
  Downloading dill-0.3.2.zip (177 kB)
Collecting more-itertools
  Downloading more_itertools-8.5.0-py3-none-any.whl (44 kB)
Requirement already satisfied: six>=1.5 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from python-dateutil>=2.7.3->pandas->CAT==0.9.10) (1.15.0)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Collecting noodles==0.3.3
  Downloading Noodles-0.3.3-py3-none-any.whl (86 kB)
Collecting filelock
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting graphviz
  Downloading graphviz-0.14.2-py2.py3-none-any.whl (18 kB)
Collecting ujson
  Downloading ujson-4.0.1-cp38-cp38-manylinux1_x86_64.whl (181 kB)
Building wheels for collected packages: CAT, pyyaml, plams, qmflows, dill
  Building wheel for CAT (setup.py): started
  Building wheel for CAT (setup.py): finished with status 'done'
  Created wheel for CAT: filename=CAT-0.9.10-py3-none-any.whl size=394958 sha256=b4afc2c1400c1391fd1ceacca2a0a019c9d28130ed4e426742882a4b2cc2accf
  Stored in directory: /tmp/pip-ephem-wheel-cache-s_dddi41/wheels/78/a4/21/2e88ba74bbf98564b7070e94cbb0164789facefa26b2e68106
  Building wheel for pyyaml (setup.py): started
  Building wheel for pyyaml (setup.py): finished with status 'done'
  Created wheel for pyyaml: filename=PyYAML-5.3.1-cp38-cp38-linux_x86_64.whl size=44619 sha256=67c67ed522ac70d34527ba182c4f94771abc52f0035615b250fb3f8afc8c3558
  Stored in directory: /tmp/pip-ephem-wheel-cache-s_dddi41/wheels/13/90/db/290ab3a34f2ef0b5a0f89235dc2d40fea83e77de84ed2dc05c
  Building wheel for plams (setup.py): started
  Building wheel for plams (setup.py): finished with status 'done'
  Created wheel for plams: filename=plams-1.4-py3-none-any.whl size=203246 sha256=848286c43d5797ed299872b14b028969e84915106b0a585d6118d1a8ef838ff9
  Stored in directory: /tmp/pip-ephem-wheel-cache-s_dddi41/wheels/53/8d/64/d31b7d8cc5183e444c6ccc48bfc86a083139ee71fde65490f9
  Building wheel for qmflows (setup.py): started
  Building wheel for qmflows (setup.py): finished with status 'done'
  Created wheel for qmflows: filename=qmflows-0.10.5-py3-none-any.whl size=75018 sha256=0800d4a657da9ee9fb5f7bd0144e4e5bb239d1d0911cfe394f9f428819e690b2
  Stored in directory: /tmp/pip-ephem-wheel-cache-s_dddi41/wheels/b5/3f/2b/7ef595fd304be2cb8deb985ae66e61d7f7fb9cc94c4a8351db
  Building wheel for dill (setup.py): started
  Building wheel for dill (setup.py): finished with status 'done'
  Created wheel for dill: filename=dill-0.3.2-py3-none-any.whl size=78912 sha256=03e78ee74c75d740d541f99efc33cb8d946b7db5de9d393a8acbe01306f97d2b
  Stored in directory: /tmp/pip-ephem-wheel-cache-s_dddi41/wheels/93/7f/7d/78ec535a4340ef2696aad8b17fe8bb063d56301bd62881b069
Successfully built CAT pyyaml plams qmflows dill
Installing collected packages: ujson, graphviz, dill, pyyaml, plams, noodles, Nano-Utils, more-itertools, filelock, contextlib2, scipy, schema, qmflows, AssertionLib, CAT
Successfully installed AssertionLib-3.1.3 CAT-0.9.10 Nano-Utils-1.1.2 contextlib2-0.6.0.post1 dill-0.3.2 filelock-3.0.12 graphviz-0.14.2 more-itertools-8.5.0 noodles-0.3.3 plams-1.4 pyyaml-5.3.1 qmflows-0.10.5 schema-0.7.2 scipy-1.5.3 ujson-4.0.1

[rtd-command-info] start-time: 2020-10-27T13:21:59.316753Z, end-time: 2020-10-27T13:22:13.391150Z, duration: 14, exit-code: 1
/home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir --use-feature 2020-resolver .[doc]
Processing /home/docs/checkouts/readthedocs.org/user_builds/cat/checkouts/latest
Requirement already satisfied: Nano-Utils>=0.4.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.2)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: scipy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.5.3)
Requirement already satisfied: pandas in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.3)
Requirement already satisfied: pyyaml>=5.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (5.3.1)
Requirement already satisfied: schema in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (0.7.2)
Requirement already satisfied: AssertionLib>=2.2.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (3.1.3)
Requirement already satisfied: sphinx_rtd_theme in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (0.4.3)
Requirement already satisfied: Nano-Utils>=0.4.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.2)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: scipy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.5.3)
Requirement already satisfied: pandas in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.3)
Requirement already satisfied: pyyaml>=5.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (5.3.1)
Requirement already satisfied: schema in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (0.7.2)
Requirement already satisfied: AssertionLib>=2.2.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (3.1.3)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: python-dateutil>=2.7.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from pandas->CAT==0.9.10) (2.8.1)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: pytz>=2017.2 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from pandas->CAT==0.9.10) (2020.1)
Collecting schema
  Downloading schema-0.7.3-py2.py3-none-any.whl (16 kB)
Requirement already satisfied: contextlib2>=0.5.5 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from schema->CAT==0.9.10) (0.6.0.post1)
Requirement already satisfied: Nano-Utils>=0.4.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.2)
Collecting plams@ git+https://github.com/SCM-NV/PLAMS@a5696ce62c09153a9fa67b2b03a750913e1d0924
  Cloning https://github.com/SCM-NV/PLAMS (to revision a5696ce62c09153a9fa67b2b03a750913e1d0924) to /tmp/pip-install-yh4ffopi/plams_93e99993a26f4b0db2f05e986b7c21e6
Requirement already satisfied: dill>=0.2.4 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from plams@ git+https://github.com/SCM-NV/PLAMS@a5696ce62c09153a9fa67b2b03a750913e1d0924->CAT==0.9.10) (0.3.2)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Collecting qmflows@ git+https://github.com/SCM-NV/qmflows@master
  Cloning https://github.com/SCM-NV/qmflows (to revision master) to /tmp/pip-install-yh4ffopi/qmflows_b36ab95ea4ef4136b20984996adf243c
Requirement already satisfied: more-itertools in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (8.5.0)
Requirement already satisfied: h5py in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (2.10.0)
Requirement already satisfied: numpy in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.19.2)
Requirement already satisfied: pandas in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (1.1.3)
Requirement already satisfied: noodles==0.3.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (0.3.3)
Requirement already satisfied: pyparsing in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (2.4.7)
Requirement already satisfied: pyyaml>=5.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from CAT==0.9.10) (5.3.1)
Requirement already satisfied: filelock in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from qmflows@ git+https://github.com/SCM-NV/qmflows@master->CAT==0.9.10) (3.0.12)
Collecting sphinx<3.1,>=2.4
  Downloading Sphinx-3.0.4-py3-none-any.whl (2.8 MB)
Requirement already satisfied: Jinja2>=2.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (2.11.2)
Requirement already satisfied: babel>=1.3 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (2.8.0)
Requirement already satisfied: sphinxcontrib-applehelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.0.2)
Requirement already satisfied: alabaster<0.8,>=0.7 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (0.7.12)
Requirement already satisfied: sphinxcontrib-jsmath in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.0.1)
Requirement already satisfied: setuptools in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (50.3.0.post20201006)
Requirement already satisfied: sphinxcontrib-serializinghtml in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.1.4)
Requirement already satisfied: packaging in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (20.4)
Requirement already satisfied: docutils>=0.12 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (0.16)
Requirement already satisfied: Pygments>=2.0 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (2.7.1)
Requirement already satisfied: imagesize in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.2.0)
Requirement already satisfied: sphinxcontrib-devhelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.0.2)
Requirement already satisfied: snowballstemmer>=1.1 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (2.0.0)
Requirement already satisfied: sphinxcontrib-htmlhelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.0.3)
Requirement already satisfied: sphinxcontrib-qthelp in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (1.0.3)
Requirement already satisfied: requests>=2.5.0 in /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/lib/python3.8/site-packages (from sphinx<3.1,>=2.4->CAT==0.9.10) (2.24.0)
Collecting sphinx_rtd_theme
  Downloading sphinx_rtd_theme-0.5.0-py2.py3-none-any.whl (10.8 MB)
Collecting data-CAT@ git+https://github.com/nlesc-nano/data-CAT@master
  Cloning https://github.com/nlesc-nano/data-CAT (to revision master) to /tmp/pip-install-yh4ffopi/data-cat_08faede0e2f34fbfa6aa04ce59788cbc
    ERROR: Command errored out with exit status 1:
     command: /home/docs/checkouts/readthedocs.org/user_builds/cat/conda/latest/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yh4ffopi/data-cat_08faede0e2f34fbfa6aa04ce59788cbc/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yh4ffopi/data-cat_08faede0e2f34fbfa6aa04ce59788cbc/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-9ccltaos
         cwd: /tmp/pip-install-yh4ffopi/data-cat_08faede0e2f34fbfa6aa04ce59788cbc/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-yh4ffopi/data-cat_08faede0e2f34fbfa6aa04ce59788cbc/setup.py", line 48, in <module>
        raise exc
    ModuleNotFoundError: 'Data-CAT' requires the 'rdkit' package: https://anaconda.org/conda-forge/rdkit
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

``
</details>