### PR TITLE
Make `dummy` and `functional_groups` aliases for `anchor`

### DIFF
--- a/CAT/attachment/ligand_anchoring.py
+++ b/CAT/attachment/ligand_anchoring.py
@@ -59,7 +59,7 @@ def init_ligand_anchoring(ligand_df: SettingsDataFrame) -> SettingsDataFrame:
     # Unpack arguments
     settings = ligand_df.settings.optional
     split = settings.ligand.split
-    functional_groups = settings.ligand.functional_groups
+    functional_groups = settings.ligand.anchor
 
     # Find all functional groups; return a copy of each mol for each functional group
     mol_list = []

--- a/CAT/data_handling/validate_input.py
+++ b/CAT/data_handling/validate_input.py
@@ -55,6 +55,7 @@ def _validate_multi_lig(s: Settings) -> None:
     anchor = s.optional.qd.multi_ligand.anchor
     if anchor is None:
         anchor = s.optional.qd.multi_ligand.dummy
+        s.optional.qd.multi_ligand.anchor = anchor
     del s.optional.qd.multi_ligand.dummy
 
     if f is anchor is None:

--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -285,11 +285,21 @@ core_schema: Schema = Schema({
     'dirname':
         And(str, error='optional.core.dirname expects a string'),
 
-    Optional_('dummy', default=17):  # Return a tuple of atomic numbers
+    # Alias for `optional.core.anchor`
+    Optional_('dummy', default=None):  # Return a tuple of atomic numbers
         Or(
+            None,
             And(val_int, Use(lambda n: to_atnum(int(n)))),
             And(str, Use(to_atnum)),
             error='optional.core.dummy expects a valid atomic number (int) or symbol (string)'
+        ),
+
+    Optional_('anchor', default=None):  # Return a tuple of atomic numbers
+        Or(
+            None,
+            And(val_int, Use(lambda n: to_atnum(int(n)))),
+            And(str, Use(to_atnum)),
+            error='optional.core.anchor expects a valid atomic number (int) or symbol (string)'
         ),
 
     Optional_('subset', default=None):
@@ -445,6 +455,22 @@ ligand_schema: Schema = Schema({
     'dirname':
         And(str, error='optional.ligand.dirname expects a string'),
 
+    Optional_('anchor', default=None):
+        Or(
+            None,
+            And(str, Use(lambda n: (n,))),
+            And(
+                abc.Collection,
+                lambda n: all(isinstance(i, str) for i in n),
+                lambda n: len(n) == len(set(n)),
+                Use(to_tuple),
+                error='optional.ligand.anchor expects a list of unique SMILES strings'
+            ),
+            error=('optional.ligand.anchor expects None (NoneType), a SMILES string, '
+                   'or a list of unique SMILES string')
+        ),
+
+    # Alias for `optional.ligand.anchor`
     Optional_('functional_groups', default=None):
         Or(
             None,
@@ -913,6 +939,16 @@ multi_ligand_schema: Schema = Schema({
             Use(tuple)
         ),
 
+    Optional_('anchor', default=None):
+        Or(
+            None,
+            And(abc.Collection,
+                lambda n: not isinstance(n, str),
+                lambda n: len(set(n)) == len(n),
+                Use(lambda n: to_tuple(n, func=to_atnum)))
+        ),
+
+    # Alias for `optional.qd.multi_ligand.anchor`
     Optional_('dummy', default=None):
         Or(
             None,

--- a/CAT/multi_ligand.py
+++ b/CAT/multi_ligand.py
@@ -26,12 +26,12 @@ def init_multi_ligand(qd_df):
     """Initialize the multi-ligand attachment procedure."""
     workflow = WorkFlow.from_template(qd_df, name='multi_ligand')
 
-    if workflow.dummy is not None:
-        sequence = [to_symbol(i) for i in workflow.dummy]
+    if workflow.anchor is not None:
+        sequence = [to_symbol(i) for i in workflow.anchor]
     elif workflow.f is not None:
         sequence = [str(i) for i in workflow.f]
     else:
-        raise TypeError("'workflow.f' and 'workflow.dummy' cannot be both 'None'")
+        raise TypeError("'workflow.f' and 'workflow.anchor' cannot be both 'None'")
 
     columns_iter1 = ('/'.join(item for item in sequence[:i]) for i in range(1, 1+len(sequence)))
     columns_iter2 = (('multi ligand', i) for i in columns_iter1)
@@ -50,15 +50,15 @@ def init_multi_ligand(qd_df):
 
 @overload
 def multi_lig(qd_series: pd.Series, ligands: Iterable[str],
-              dummy: Sequence[Union[str, int]], f: None,
+              anchor: Sequence[Union[str, int]], f: None,
               **kwargs: Any) -> pd.DataFrame:
     ...
 @overload  # noqa: E302
 def multi_lig(qd_series: pd.Series, ligands: Iterable[str],
-              dummy: None, f: Sequence[float],
+              anchor: None, f: Sequence[float],
               **kwargs: Any) -> pd.DataFrame:
     ...
-def multi_lig(qd_series, ligands, dummy=None, f=None, **kwargs):  # noqa: E302
+def multi_lig(qd_series, ligands, anchor=None, f=None, **kwargs):  # noqa: E302
     """Attach multiple non-unique **ligands** to each qd in **qd_series**."""
     # Read and parse the SMILES strings
     ligands = smiles_to_lig(list(ligands),
@@ -75,21 +75,21 @@ def multi_lig(qd_series, ligands, dummy=None, f=None, **kwargs):  # noqa: E302
     if f is not None:
         raise NotImplementedError("'f != None' is not yet implemented")
 
-    if dummy is not None:
-        return _multi_lig_dummy(qd_series, ligands, kwargs['path'], dummy, kwargs['allignment'])
+    if anchor is not None:
+        return _multi_lig_anchor(qd_series, ligands, kwargs['path'], anchor, kwargs['allignment'])
     elif f is not None:
         return [[NotImplemented]]
     else:
-        raise TypeError("'f' and 'dummy' cannot be both 'None'")
+        raise TypeError("'f' and 'anchor' cannot be both 'None'")
 
 
-def _multi_lig_dummy(qd_series, ligands, path, dummy, allignment) -> np.ndarray:
+def _multi_lig_anchor(qd_series, ligands, path, anchor, allignment) -> np.ndarray:
     """Gogogo."""
     ret = np.empty((len(ligands), len(qd_series)), dtype=object)
     for i, qd in enumerate(qd_series):
         qd = qd.copy()
 
-        for j, (ligand, atnum) in enumerate(zip(ligands, dummy)):
+        for j, (ligand, atnum) in enumerate(zip(ligands, anchor)):
             try:
                 atoms = [at for at in qd if at.atnum == atnum]
                 assert atoms

--- a/CAT/workflows/workflow_yaml.yaml
+++ b/CAT/workflows/workflow_yaml.yaml
@@ -149,10 +149,10 @@ multi_ligand:
         allignment: [optional, core, allignment]
         opt: [optional, ligand, optimize]
         split: [optional, ligand, split]
-        functional_groups: [optional, ligand, functional_groups]
+        functional_groups: [optional, ligand, anchor]
 
         ligands: [optional, qd, multi_ligand, ligands]
-        dummy: [optional, qd, multi_ligand, dummy]
+        anchor: [optional, qd, multi_ligand, anchor]
         f: [optional, qd, multi_ligand, f]
         mode: [optional, qd, multi_ligand, uniform]
         start: [optional, qd, multi_ligand, start]

--- a/docs/13_multi_ligand.rst
+++ b/docs/13_multi_ligand.rst
@@ -19,7 +19,7 @@ Multi-ligand attachment
                         - OCCC
                         - OCCCCCCC
                         - OCCCCCCCCCCCC
-                    dummy:
+                    anchor:
                         - F
                         - Br
                         - I
@@ -39,19 +39,21 @@ Multi-ligand attachment
             This argument has no value be default and must thus be provided by the user.
 
 
-    .. attribute:: optional.qd.multi_ligand.dummy
+    .. attribute:: optional.qd.multi_ligand.anchor
 
         :Parameter:     * **Type** - :class:`list` [:class:`str` or :class:`int`]
 
-        Atomic number of symbol of the core dummy atoms.
+        Atomic number of symbol of the core anchor atoms.
 
-        The first dummy atom will be assigned to the first ligand in
-        :attr:`multi_ligand.ligands<optional.qd.multi_ligand.ligands>`, the second dummy atom
+        The first anchor atom will be assigned to the first ligand in
+        :attr:`multi_ligand.ligands<optional.qd.multi_ligand.ligands>`, the second anchor atom
         to the second ligand, *etc.*.
         The list's length should consequently be of the same length as
         :attr:`multi_ligand.ligands<optional.qd.multi_ligand.ligands>`.
 
-        Works analogous to :attr:`optional.core.dummy`.
+        Works analogous to :attr:`optional.core.anchor`.
+
+        This optiona can alternatively be provided as ``optional.qd.multi_ligand.dummy``.
 
         .. note::
             This argument has no value be default and must thus be provided by the user.

--- a/docs/1_get_started.rst
+++ b/docs/1_get_started.rst
@@ -67,14 +67,14 @@ Verbose default Settings
 
         core:
             dirname: core
-            dummy: Cl
+            anchor: Cl
             subset: null
 
         ligand:
             dirname: ligand
             optimize: True
             split: True
-            functional_groups: null
+            anchor: null
             cosmo-rs: False
 
         qd:
@@ -112,13 +112,13 @@ Maximum verbose default Settings
 
         core:
             dirname: core
-            dummy: Cl
+            anchor: Cl
             subset: null
 
         ligand:
             dirname: ligand
             split: True
-            functional_groups: null
+            anchor: null
             cosmo-rs: False
             optimize:
                 use_ff: False

--- a/docs/4_optional.rst
+++ b/docs/4_optional.rst
@@ -25,13 +25,13 @@ Option                                    Description
 :attr:`optional.database.mongodb`         Options related to the MongoDB format.
 
 :attr:`optional.core.dirname`             The name of the directory where all cores will be stored.
-:attr:`optional.core.dummy`               Atomic number of symbol of the core dummy atoms.
+:attr:`optional.core.anchor`              Atomic number of symbol of the core anchor atoms.
 :attr:`optional.core.allignment`          How the to-be attached ligands should be alligned with the core.
-:attr:`optional.core.subset`              Settings related to the partial replacement of core dummy atoms.
+:attr:`optional.core.subset`              Settings related to the partial replacement of core anchor atoms.
 
 :attr:`optional.ligand.dirname`           The name of the directory where all ligands will be stored.
 :attr:`optional.ligand.optimize`          Optimize the geometry of the to-be attached ligands.
-:attr:`optional.ligand.functional_groups` Manually specify SMILES strings representing functional groups.
+:attr:`optional.ligand.anchor`            Manually specify SMILES strings representing functional groups.
 :attr:`optional.ligand.split`             If the ligand should be attached in its entirety to the core or not.
 :attr:`optional.ligand.cosmo-rs`          Perform a property calculation with COSMO-RS on the ligand.
 :attr:`optional.ligand.cdft`              Perform a conceptual DFT calculation with ADF on the ligand.
@@ -62,14 +62,14 @@ Default Settings
 
         core:
             dirname: core
-            dummy: Cl
+            anchor: Cl
             allignment: sphere
             subset: null
 
         ligand:
             dirname: ligand
             optimize: True
-            functional_groups: null
+            anchor: null
             split: True
             cosmo-rs: False
             cdft: False
@@ -236,7 +236,7 @@ Core
         optional:
             core:
                 dirname: core
-                dummy: Cl
+                anchor: Cl
                 allignment: sphere
                 subset: null
 
@@ -253,16 +253,18 @@ Core
         at the path specified in :ref:`Path`.
 
 
-    .. attribute:: optional.core.dummy
+    .. attribute:: optional.core.anchor
 
         :Parameter:     * **Type** - :class:`str` or :class:`int`
                         * **Default value** – ``17``
 
-        Atomic number of symbol of the core dummy atoms.
+        Atomic number of symbol of the core anchor atoms.
 
         The atomic number or atomic symbol of the atoms in the core which are to be
-        replaced with ligands. Alternatively, dummy atoms can be manually specified
+        replaced with ligands. Alternatively, anchor atoms can be manually specified
         with the core_indices variable.
+
+        This optiona can alternatively be provided as ``optional.core.dummy``.
 
 
     .. attribute:: optional.core.allignment
@@ -296,7 +298,7 @@ Core
         :Parameter:     * **Type** - :class:`dict`, optional
                         * **Default value** – ``None``
 
-        Settings related to the partial replacement of core dummy atoms with ligands.
+        Settings related to the partial replacement of core anchor atoms with ligands.
 
         If not ``None``, has access to six further keywords,
         the first two being the most important:
@@ -313,7 +315,7 @@ Core
 
         :Parameter:     * **Type** - :class:`float`
 
-        The fraction of core dummy atoms that will actually be exchanged for ligands.
+        The fraction of core anchor atoms that will actually be exchanged for ligands.
 
         The provided value should satisfy the following condition: :math:`0 < f \le 1`.
 
@@ -326,24 +328,24 @@ Core
         :Parameter:     * **Type** - :class:`str`
                         * **Default value** – ``"uniform"``
 
-        Defines how the dummy atom subset, whose size is defined by the fraction :math:`f`, will be generated.
+        Defines how the anchor atom subset, whose size is defined by the fraction :math:`f`, will be generated.
 
         Accepts one of the following values:
 
         * ``"uniform"``: A uniform distribution; the nearest-neighbor distances between each
-          successive dummy atom and all previous dummy atoms is maximized.
+          successive anchor atom and all previous anchor atoms is maximized.
           can be combined with :attr:`subset.cluster_size<optional.core.subset.cluster_size>`
           to create a uniform distribution of clusters of a user-specified size.
         * ``"cluster"``: A clustered distribution; the nearest-neighbor distances between each
-          successive dummy atom and all previous dummy atoms is minimized.
+          successive anchor atom and all previous anchor atoms is minimized.
         * ``"random"``: A random distribution.
 
         It should be noted that all three methods converge towards the same set
         as :math:`f` approaches :math:`1.0`.
 
         If :math:`\boldsymbol{D} \in \mathbb{R}_{+}^{n,n}` is the (symmetric) distance matrix constructed
-        from the dummy atom superset and :math:`\boldsymbol{a} \in \mathbb{N}^{m}` is the vector
-        of indices which yields the dummy atom subset. The definition of element :math:`a_{i}`
+        from the anchor atom superset and :math:`\boldsymbol{a} \in \mathbb{N}^{m}` is the vector
+        of indices which yields the anchor atom subset. The definition of element :math:`a_{i}`
         is defined below for the ``"uniform"`` distribution.
         All elements of :math:`\boldsymbol{a}` are furthermore constrained to be unique.
 
@@ -396,7 +398,7 @@ Core
         :Parameter:     * **Type** - :class:`bool`
                         * **Default value** – ``False``
 
-        Construct the dummy atom distance matrix by following the shortest path along the
+        Construct the anchor atom distance matrix by following the shortest path along the
         edges of a (triangular-faced) polyhedral approximation of the core rather than the
         shortest path through space.
 
@@ -519,7 +521,7 @@ Core
         :Parameter:     * **Type** - :class:`float`, optional
                         * **Default value** – ``None``
 
-        The probability that each new core dummy atom will be picked at random.
+        The probability that each new core anchor atom will be picked at random.
 
         Can be used in combination with ``"uniform"`` and ``"cluster"`` to introduce
         a certain degree of randomness (*i.e.* entropy).
@@ -557,7 +559,7 @@ Ligand
             ligand:
                 dirname: ligand
                 optimize: True
-                functional_groups: null
+                anchor: null
                 split: True
                 cosmo-rs: False
                 cdft: False
@@ -603,14 +605,14 @@ Ligand
                             job2: ADFJob
 
 
-    .. attribute:: optional.ligand.functional_groups
+    .. attribute:: optional.ligand.anchor
 
         :Parameter:     * **Type** - :class:`str` or :class:`tuple` [:class:`str`]
                         * **Default value** – ``None``
 
         Manually specify SMILES strings representing functional groups.
 
-        For example, with :attr:`optional.ligand.functional_groups` = ``("O[H]", "[N+].[Cl-]")`` all
+        For example, with :attr:`optional.ligand.anchor` = ``("O[H]", "[N+].[Cl-]")`` all
         ligands will be searched for the presence of hydroxides and ammonium chlorides.
 
         The first atom in each SMILES string (*i.e.* the "anchor") will be used for attaching the ligand
@@ -618,6 +620,8 @@ Ligand
         dissociated from the ligand and discarded.
 
         If not specified, the default functional groups of **CAT** are used.
+
+        This optiona can alternatively be provided as ``optional.ligand.functional_groups``.
 
         .. note::
             This argument has no value be default and will thus default to SMILES strings of the default

--- a/tests/test_files/CAT.yaml
+++ b/tests/test_files/CAT.yaml
@@ -18,7 +18,7 @@ optional:
 
     core:
         dirname: core
-        dummy: Cl
+        anchor: Cl
 
     ligand:
         dirname: ligand

--- a/tests/test_files/CAT_indices.yaml
+++ b/tests/test_files/CAT_indices.yaml
@@ -14,7 +14,7 @@ input_ligands:
 optional:
     core:
         dirname: core
-        dummy: Cl
+        anchor: Cl
 
     ligand:
         dirname: ligand

--- a/tests/test_files/input2.yaml
+++ b/tests/test_files/input2.yaml
@@ -29,14 +29,14 @@ optional:
 
     core:
         dirname: core
-        dummy: Cl
+        anchor: Cl
 
     ligand:
         dirname: ligand
         optimize: True
         split: False
         cosmo-rs: False
-        functional_groups: [N, P, O, S]
+        anchor: [N, P, O, S]
 
     qd:
         dirname: QD

--- a/tests/test_files/input3.yaml
+++ b/tests/test_files/input3.yaml
@@ -14,7 +14,7 @@ optional:
         mol_format: [pdb]
 
     core:
-        dummy: Cl
+        anchor: Cl
 
     ligand:
         optimize: True
@@ -26,6 +26,6 @@ optional:
             ligands:
                 - OCCCCCCCCCCCCC
                 - OC
-            dummy:
+            anchor:
                 - Br
                 - I

--- a/tests/test_files/input4.yaml
+++ b/tests/test_files/input4.yaml
@@ -20,7 +20,7 @@ optional:
 
     core:
         dirname: core
-        dummy: Cl
+        anchor: Cl
 
     ligand:
         dirname: ligand

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -122,6 +122,7 @@ def test_ligand_schema() -> None:
     ref = {
         'dirname': '.',
         'anchor': None,
+        'functional_groups': None,
         'optimize': {'job1': None},
         'split': True,
         'cosmo-rs': False,
@@ -162,7 +163,8 @@ def test_core_schema() -> None:
     core_dict = {'dirname': '.'}
     ref = {
         'dirname': '.',
-        'anchor': 17,
+        'anchor': None,
+        'dummy': None,
         'allignment': 'sphere',
         'subset': None
     }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -121,7 +121,7 @@ def test_ligand_schema() -> None:
     lig_dict = {'dirname': '.'}
     ref = {
         'dirname': '.',
-        'functional_groups': None,
+        'anchor': None,
         'optimize': {'job1': None},
         'split': True,
         'cosmo-rs': False,
@@ -147,13 +147,13 @@ def test_ligand_schema() -> None:
     lig_dict['cosmo-rs'] = True
     assertion.eq(ligand_schema.validate(lig_dict)['cosmo-rs'], {'job1': 'AMSJob'})
 
-    lig_dict['functional_groups'] = 1  # Exception: incorrect type
+    lig_dict['anchor'] = 1  # Exception: incorrect type
     assertion.assert_(ligand_schema.validate, lig_dict, exception=SchemaError)
-    lig_dict['functional_groups'] = 'CO'
-    assertion.eq(ligand_schema.validate(lig_dict)['functional_groups'], ('CO',))
-    lig_dict['functional_groups'] = ['CO']
-    assertion.eq(ligand_schema.validate(lig_dict)['functional_groups'], ('CO',))
-    lig_dict['functional_groups'] = ['CO', 'CO']  # Exception: duplicate elements
+    lig_dict['anchor'] = 'CO'
+    assertion.eq(ligand_schema.validate(lig_dict)['anchor'], ('CO',))
+    lig_dict['anchor'] = ['CO']
+    assertion.eq(ligand_schema.validate(lig_dict)['anchor'], ('CO',))
+    lig_dict['anchor'] = ['CO', 'CO']  # Exception: duplicate elements
     assertion.assert_(ligand_schema.validate, lig_dict, exception=SchemaError)
 
 
@@ -162,21 +162,21 @@ def test_core_schema() -> None:
     core_dict = {'dirname': '.'}
     ref = {
         'dirname': '.',
-        'dummy': 17,
+        'anchor': 17,
         'allignment': 'sphere',
         'subset': None
     }
 
     assertion.eq(core_schema.validate(core_dict), ref)
 
-    core_dict['dummy'] = 1.1  # Exception: incorrect value
+    core_dict['anchor'] = 1.1  # Exception: incorrect value
     assertion.assert_(core_schema.validate, core_dict, exception=SchemaError)
-    core_dict['dummy'] = 'H'
-    assertion.eq(core_schema.validate(core_dict)['dummy'], 1)
-    core_dict['dummy'] = 1
-    assertion.eq(core_schema.validate(core_dict)['dummy'], 1)
-    core_dict['dummy'] = 1.0
-    assertion.eq(core_schema.validate(core_dict)['dummy'], 1)
+    core_dict['anchor'] = 'H'
+    assertion.eq(core_schema.validate(core_dict)['anchor'], 1)
+    core_dict['anchor'] = 1
+    assertion.eq(core_schema.validate(core_dict)['anchor'], 1)
+    core_dict['anchor'] = 1.0
+    assertion.eq(core_schema.validate(core_dict)['anchor'], 1)
 
     core_dict['allignment'] = 1.1  # Exception: incorrect type
     assertion.assert_(core_schema.validate, core_dict, exception=SchemaError)

--- a/tests/test_validate_input.py
+++ b/tests/test_validate_input.py
@@ -64,7 +64,7 @@ def test_validate_input() -> None:
 
     ref.forcefield = Settings()
 
-    func_groups = s.optional.ligand.pop('functional_groups')
+    func_groups = s.optional.ligand.pop('anchor')
 
     try:
         for mol in func_groups:

--- a/tests/test_validate_input.py
+++ b/tests/test_validate_input.py
@@ -34,7 +34,7 @@ def test_validate_input() -> None:
 
     ref = Settings()
     ref.core.dirname = join(PATH, 'core')
-    ref.core.dummy = 17
+    ref.core.anchor = 17
     ref.core.allignment = 'sphere'
     ref.core.subset = None
 


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/CAT/issues/163.

Adds the new `optional.core.anchor` and `optional.ligand.functional_groups` options,
which are respectively aliases for the old `optional.core.dummy` and `optional.ligand.functional_groups` options.