### PR TITLE
ENH: Added the new `bulkiness.h_lim` and `bulkiness.d` options

### DIFF
--- a/CAT/data_handling/validate_input.py
+++ b/CAT/data_handling/validate_input.py
@@ -32,7 +32,8 @@ from .validation_schemas import (
     ligand_opt_schema,
     subset_schema,
     multi_ligand_schema,
-    cdft_schema
+    cdft_schema,
+    bulkiness_schema,
 )
 
 from .validate_ff import validate_ff, update_ff_jobs
@@ -160,6 +161,8 @@ def validate_input(s: Settings, validate_only: bool = True) -> None:
         if s.optional.qd.multi_ligand:
             s.optional.qd.multi_ligand = multi_ligand_schema.validate(s.optional.qd.multi_ligand)
             _validate_multi_lig(s)
+        if s.optional.qd.bulkiness:
+            s.optional.qd.bulkiness = bulkiness_schema.validate(s.optional.qd.bulkiness)
 
         # Create forcefield Job Settings
         if s.optional.forcefield:

--- a/CAT/workflows/workflow_yaml.yaml
+++ b/CAT/workflows/workflow_yaml.yaml
@@ -133,6 +133,8 @@ bulkiness:
         thread_safe: [optional, database, thread_safe]
 
         path: [optional, qd, dirname]
+        d: [optional, qd, bulkiness, d]
+        h_lim: [optional, qd, bulkiness, h_lim]
 
 multi_ligand:
     description: multi-ligand attachment

--- a/docs/4_optional.rst
+++ b/docs/4_optional.rst
@@ -808,16 +808,41 @@ QD
 
     .. attribute:: optional.qd.bulkiness
 
-        :Parameter:     * **Type** - :class:`bool`
+        :Parameter:     * **Type** - :class:`bool` or :class:`dict`
                         * **Default value** – ``False``
 
         Calculate the :math:`V_{bulk}`, a ligand- and core-specific descriptor of a ligands' bulkiness.
+
+        Supplying a dictionary grants access to the two additional :attr:`~optional.qd.bulkiness.h_lim`
+        and :attr:`~optional.qd.bulkiness.d` sub-keys.
 
         .. math::
             :label: 5
 
             V(r_{i}, h_{i}; d, h_{lim}) =
             \sum_{i=1}^{n} e^{r_{i}} (\frac{2 r_{i}}{d} - 1)^{+} (1 - \frac{h_{i}}{h_{lim}})^{+}
+
+
+    .. attribute:: optional.qd.bulkiness.h_lim
+
+        :Parameter:     * **Type** - :class:`float` or :data:`None`
+                        * **Default value** – ``10.0``
+
+        Default value of the :math:`h_{lim}` parameter in :attr:`~optional.qd.bulkiness`.
+
+        Set to :data:`None` to disable the :math:`h_{lim}`-based cutoff.
+
+
+    .. attribute:: optional.qd.bulkiness.d
+
+        :Parameter:     * **Type** - :class:`float`, :data:`None` or ``"auto"``
+                        * **Default value** – ``"auto"``
+
+        Default value of the :math:`d` parameter in :attr:`~optional.qd.bulkiness`.
+
+        Set to ``"auto"`` to automatically infer this parameters value based on the mean
+        nearest-neighbor distance among the core anchor atoms.
+        Set to :data:`None` to disable the :math:`d`-based cutoff.
 
 
     .. attribute:: optional.qd.activation_strain


### PR DESCRIPTION
Adds two new bulkiness-related options:
``` yaml
optional:
    qd:
        bulkiness:
            h_lim: 10.0
            d: "auto"
```

Dependent on https://github.com/nlesc-nano/nano-CAT/pull/69.