### PR TITLE
MAINT: Do not call `os.path.abspath()` when loading jobs

### DIFF
--- a/CAT/gen_job_manager.py
+++ b/CAT/gen_job_manager.py
@@ -124,9 +124,7 @@ class GenJobManager(JobManager):
 
         """
         # Raise an error if **filename** cannot be found
-        if isfile(filename):
-            filename = abspath(filename)
-        else:
+        if not isfile(filename):
             raise FileError(f'File {filename} not present')
 
         # Read the has from filename


### PR DESCRIPTION
This can cause issue with certain parallel-distribution systems, 
the absolute path referring to the login node rather than the compute nodes.

Ping @felipeZ 