### PR TITLE
TST: Freeze the pip version

### DIFF
--- a/.environment.yaml
+++ b/.environment.yaml
@@ -4,17 +4,16 @@ channels:
     - conda-forge
 
 dependencies:
-    - pip
+    - pip<=20.2
     - python=3.8
     - h5py
     - rdkit
     - pandas
     - numpy
     - scipy
-    
+
     - pip:
         - data-CAT@git+https://github.com/nlesc-nano/data-CAT@master
         - nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@master
         - plams@git+https://github.com/SCM-NV/PLAMS@a5696ce62c09153a9fa67b2b03a750913e1d0924
         - qmflows@git+https://github.com/SCM-NV/qmflows@master
-

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,7 @@ jobs:
                 conda-channels: anaconda
 
             - name: Install conda-based dependencies
-              run: conda install -c conda-forge h5py rdkit=2019.09.2
+              run: conda install -c conda-forge h5py rdkit=2019.09.2 'pip<=20.2'
 
             - name: Install dependencies
               run: pip install -e .[test]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,8 @@ jobs:
                 conda-channels: anaconda
 
             - name: Install conda-based dependencies
-              run: conda install -c conda-forge h5py rdkit=2019.09.2 'pip<=20.2'
+              shell: bash -l {0}
+              run: conda install -c conda-forge h5py rdkit=2019.09.2 "pip<=20.2"
 
             - name: Install dependencies
               run: pip install -e .[test]


### PR DESCRIPTION
Pip 20.3 has issues with handling the CAT/data-CAT dependency chain:


from https://github.com/nlesc-nano/CAT/runs/1588660340?check_suite_focus=true:
```
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies

The conflict is caused by:
    cat[test] 0.9.11 depends on cat 0.9.11 (from /home/runner/work/CAT/CAT)
    data-cat 0.5.2 depends on cat 0.9.11 (from git+https://github.com/nlesc-nano/CAT)

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```