### PR TITLE
MAINT: Raise a `NotImplementedError` if a core has an insufficient number of anchors

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Install conda-based dependencies
               shell: bash -l {0}
-              run: conda install -c conda-forge h5py rdkit=2019.09.2 "pip<=20.2"
+              run: conda install -c conda-forge rdkit=2019.09.2 "pip<=20.2"
 
             - name: Install dependencies
               run: pip install -e .[test]

--- a/CAT/base.py
+++ b/CAT/base.py
@@ -236,6 +236,12 @@ def prep_core(core_df: SettingsDataFrame) -> SettingsDataFrame:
             raise MoleculeError(f"{repr(to_symbol(anchor))} was specified as core anchor atom, yet "
                                 f"no matching atoms were found in {core.properties.name} "
                                 f"(formula: {formula})")
+        elif len(dummies) < 4 and core_df.settings.optional.core.allignment == "surface":
+            raise NotImplementedError(
+                '`optional.core.allignment = "surface"` is not supported for cores with less '
+                f'than 4 anchor atoms ({core.get_formula()}); consider using '
+                '`optional.core.allignment = "sphere"`'
+            )
 
         # Delete all core anchor atoms
         for at in dummies:

--- a/docs/4_optional.rst
+++ b/docs/4_optional.rst
@@ -277,7 +277,7 @@ Core
         Has two allowed values:
 
         * ``"surface"``: Define the core vectors as those orthogonal to the cores
-          surface.
+          surface. Not this option requires at least four core anchor atoms.
           The surface is herein defined by a convex hull constructed from the core.
         * ``"sphere"``: Define the core vectors as those drawn from the core anchor
           atoms to the cores center.

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'Nano-Utils>=0.4.3',
+        'h5py',
         'numpy',
         'scipy',
         'pandas',

--- a/tests/test_CAT.py
+++ b/tests/test_CAT.py
@@ -6,7 +6,7 @@ from typing import Optional
 import yaml
 import pytest
 from scm.plams import Settings
-from nanoutils import delete_finally, ignore_if
+from nanoutils import delete_finally
 
 from CAT.base import prep
 
@@ -22,9 +22,27 @@ QD_PATH = PATH / 'qd'
 DB_PATH = PATH / 'database'
 
 
-@pytest.mark.slow
-@ignore_if(NANOCAT_EX)
 @delete_finally(LIG_PATH, QD_PATH, DB_PATH)
+@pytest.mark.skipif(NANOCAT_EX is not None, reason=str(NANOCAT_EX))
+def test_cat_fail() -> None:
+    """Tests for the CAT package."""
+    yaml_path = PATH / 'CAT.yaml'
+    with open(yaml_path, 'r') as f:
+        arg = Settings(yaml.load(f, Loader=yaml.FullLoader))
+
+    arg.path = PATH
+    del arg.optional.core.anchor
+    arg.optional.ligand["cosmo-rs"] = False
+    arg.optional.qd.activation_strain = False
+    arg.optional.qd.optimize = False
+    arg.input_cores[0]["Cd68Se55.xyz"]["indices"] = [1, 2, 3]
+    with pytest.raises(NotImplementedError):
+        prep(arg)
+
+
+@pytest.mark.slow
+@delete_finally(LIG_PATH, QD_PATH, DB_PATH)
+@pytest.mark.skipif(NANOCAT_EX is not None, reason=str(NANOCAT_EX))
 def test_cat() -> None:
     """Tests for the CAT package."""
     yaml_path = PATH / 'CAT.yaml'


### PR DESCRIPTION
The user should either provide more anchor atoms (>= 4) or switch to `optional.core.allignment = "sphere"`.