### PR TITLE
BUG: Use all rdkit sanitize flags when importing input compounds

### DIFF
--- a/CAT/attachment/ligand_anchoring.py
+++ b/CAT/attachment/ligand_anchoring.py
@@ -152,11 +152,10 @@ def get_functional_groups(functional_groups: Optional[Iterable[str]] = None,
 
 def _smiles_to_rdmol(smiles: str) -> Chem.Mol:
     """Convert a SMILES string into an rdkit Mol; supports explicit hydrogens."""
-    # RDKit tends to remove explicit hydrogens if SANITIZE_ADJUSTHS is enabled
-    sanitize = Chem.SanitizeFlags.SANITIZE_ALL ^ Chem.SanitizeFlags.SANITIZE_ADJUSTHS
+    # Perform the sanitization in 2 steps so that `MolFromSmiles` doesn't remove explicit hydrogens
     try:
         mol = Chem.MolFromSmiles(smiles, sanitize=False)
-        Chem.rdmolops.SanitizeMol(mol, sanitizeOps=sanitize)
+        Chem.rdmolops.SanitizeMol(mol, sanitizeOps=Chem.SanitizeFlags.SANITIZE_ALL)
     except Exception as ex:
         raise ex.__class__(f'Failed to parse the following SMILES string: {repr(smiles)}\n\n{ex}')
     return mol

--- a/CAT/data_handling/mol_import.py
+++ b/CAT/data_handling/mol_import.py
@@ -180,9 +180,9 @@ def read_mol_smiles(mol_dict: Settings) -> Optional[Molecule]:
 
 
 def _from_smiles(smiles: str) -> Molecule:
-    sanitize = Chem.SanitizeFlags.SANITIZE_ALL ^ Chem.SanitizeFlags.SANITIZE_ADJUSTHS
+    # Perform the sanitization in 2 steps so that `MolFromSmiles` doesn't remove explicit hydrogens
     _rdmol = Chem.MolFromSmiles(smiles, sanitize=False)
-    Chem.rdmolops.SanitizeMol(_rdmol, sanitizeOps=sanitize)
+    Chem.rdmolops.SanitizeMol(_rdmol, sanitizeOps=Chem.SanitizeFlags.SANITIZE_ALL)
 
     rdmol = Chem.AddHs(_rdmol)
     rdmol.SetProp('smiles', smiles)


### PR DESCRIPTION
This PR removes that custom sanitization flag used when importing molecules via SMILES string, 
as this could lead to the loss of _cis_/_trans_ information.

Aforementioned sanitization flag is required for the preservation of explicit hydrogens, but as input molecules
are completely capped with hydrogens anyway this is, in fact, redundant. The offending code can therefore 
safely be removed.