### PR TITLE
ENH: Allow specifying the format type of the anchor `group`

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -91,8 +91,6 @@ jobs:
 
             -   name: Run flake8
                 run: flake8 CAT tests
-                continue-on-error: true
 
             -   name: Run pydocstyle
                 run: pydocstyle CAT tests
-                continue-on-error: true

--- a/CAT/_mol_str_parser.py
+++ b/CAT/_mol_str_parser.py
@@ -1,0 +1,74 @@
+"""A module with various RDKit-based string-to-mol parser.
+
+Index
+-----
+.. currentmodule:: CAT._mol_str_parsers
+.. autosummary::
+    str_to_rdmol
+    FormatEnum
+
+API
+---
+.. autofunction:: str_to_rdmol
+.. autoclass:: FormatEnum
+
+"""
+
+# flake8: noqa: E501
+
+import enum
+import textwrap
+from typing import Any, Callable
+
+from nanoutils import PartialPrepend
+
+try:
+    from rdkit import Chem
+except ModuleNotFoundError:
+    # Precaution against sphinx mocking raising a TypeError
+    FLAGS = 0
+else:
+    FLAGS = Chem.SanitizeFlags.SANITIZE_ALL ^ Chem.SanitizeFlags.SANITIZE_ADJUSTHS
+
+__all__ = ["FormatEnum", "str_to_rdmol"]
+
+
+def str_to_rdmol(
+    string: str,
+    parser: Callable[[str], Chem.Mol],
+    kind: str = "",
+    **kwargs: Any,
+) -> Chem.Mol:
+    """Convert a SMILES string into an rdkit Mol; supports explicit hydrogens."""
+    # RDKit tends to remove explicit hydrogens if SANITIZE_ADJUSTHS is enabled
+    try:
+        mol = parser(string, **kwargs)
+        assert mol is not None
+        if not kwargs.get("sanitize", True):
+            Chem.SanitizeMol(mol, sanitizeOps=FLAGS)
+    except Exception as ex:
+        err_str = string if "\n" not in string else "\n" + textwrap.indent(string, 4 * " ")
+        raise ValueError(f'Failed to parse the following {kind}: {err_str!r}') from ex
+    return mol
+
+
+class FormatEnum(enum.Enum):
+    """An enum with various rdkit-based string-parsing options."""
+
+    FASTA = PartialPrepend(str_to_rdmol, Chem.MolFromFASTA, "FASTA string", sanitize=False)
+    HELM = PartialPrepend(str_to_rdmol, Chem.MolFromHELM, "HELM string", sanitize=False)
+    INCHI = PartialPrepend(str_to_rdmol, Chem.MolFromInchi, "InChi string", sanitize=False, removeHs=False)
+    MOL2 = PartialPrepend(str_to_rdmol, Chem.MolFromMol2Block, "Mol2 block", sanitize=False, removeHs=False)
+    MOL2_FILE = PartialPrepend(str_to_rdmol, Chem.MolFromMol2File, "Mol2 file", sanitize=False, removeHs=False)
+    MOL = PartialPrepend(str_to_rdmol, Chem.MolFromMolBlock, "Mol block", sanitize=False, removeHs=False)
+    MOL_FILE = PartialPrepend(str_to_rdmol, Chem.MolFromMolFile, "Mol file", sanitize=False, removeHs=False)
+    PDB = PartialPrepend(str_to_rdmol, Chem.MolFromPDBBlock, "PDB block", sanitize=False, removeHs=False)
+    PDB_FILE = PartialPrepend(str_to_rdmol, Chem.MolFromPDBFile, "PDB file", sanitize=False, removeHs=False)
+    PNG = PartialPrepend(str_to_rdmol, Chem.MolFromPNGString, "PNG string")
+    PNG_FILE = PartialPrepend(str_to_rdmol, Chem.MolFromPNGFile, "PNG file")
+    SVG = PartialPrepend(str_to_rdmol, Chem.MolFromRDKitSVG, "SVG string", sanitize=False, removeHs=False)
+    SEQUENCE = PartialPrepend(str_to_rdmol, Chem.MolFromSequence, "sequence string", sanitize=False)
+    SMARTS = PartialPrepend(str_to_rdmol, Chem.MolFromSmarts, "SMARTS string")
+    SMILES = PartialPrepend(str_to_rdmol, Chem.MolFromSmiles, "SMILES string", sanitize=False)
+    TPL = PartialPrepend(str_to_rdmol, Chem.MolFromTPLBlock, "TPL block", sanitize=False)
+    TPL_FILE = PartialPrepend(str_to_rdmol, Chem.MolFromTPLFile, "TPL file", sanitize=False)

--- a/CAT/attachment/ligand_anchoring.py
+++ b/CAT/attachment/ligand_anchoring.py
@@ -34,7 +34,7 @@ import scm.plams.interfaces.molecule.rdkit as molkit
 from rdkit import Chem
 
 from ..logger import logger
-from ..utils import get_template, AnchorTup, KindEnum, get_formula
+from ..utils import get_template, AnchorTup, KindEnum, get_formula, FormatEnum
 from ..mol_utils import separate_mod   # noqa: F401
 from ..workflows import MOL, FORMULA, HDF5_INDEX, OPT
 from ..settings_dataframe import SettingsDataFrame
@@ -154,16 +154,7 @@ def get_functional_groups(
     return tuple(_smiles_to_rdmol(smiles) for smiles in func_groups)
 
 
-def _smiles_to_rdmol(smiles: str) -> Chem.Mol:
-    """Convert a SMILES string into an rdkit Mol; supports explicit hydrogens."""
-    # RDKit tends to remove explicit hydrogens if SANITIZE_ADJUSTHS is enabled
-    sanitize = Chem.SanitizeFlags.SANITIZE_ALL ^ Chem.SanitizeFlags.SANITIZE_ADJUSTHS
-    try:
-        mol = Chem.MolFromSmiles(smiles, sanitize=False)
-        Chem.rdmolops.SanitizeMol(mol, sanitizeOps=sanitize)
-    except Exception as ex:
-        raise ValueError(f'Failed to parse the following SMILES string: {smiles!r}') from ex
-    return mol
+_smiles_to_rdmol = FormatEnum.SMILES.value
 
 
 def find_substructure(

--- a/CAT/multi_ligand.py
+++ b/CAT/multi_ligand.py
@@ -95,7 +95,7 @@ def _multi_lig_anchor(qd_series, ligands, path, anchor, allignment) -> np.ndarra
                 assert atoms
             except AssertionError as ex:
                 raise MoleculeError(f'Failed to identify {to_symbol(atnum)!r} in '
-                                    f'{get_formula(q)!r}') from ex
+                                    f'{get_formula(qd)!r}') from ex
 
             coords = Molecule.as_array(None, atom_subset=atoms)
             qd.properties.dummies = np.array(coords, ndmin=2, dtype=float)

--- a/CAT/utils.py
+++ b/CAT/utils.py
@@ -60,12 +60,13 @@ from scm.plams import (
 from .logger import logger
 from .mol_utils import to_atnum
 from .gen_job_manager import GenJobManager
+from ._mol_str_parser import FormatEnum
 
 __all__ = [
     'JOB_MAP', 'check_sys_var', 'dict_concatenate', 'get_template',
     'cycle_accumulate', 'iter_repeat', 'get_nearest_neighbors',
     'log_traceback_locals', 'KindEnum', 'AnchorTup', 'AllignmentEnum',
-    'AllignmentTup'
+    'AllignmentTup', 'FormatEnum',
 ]
 
 JOB_MAP: Mapping[Type[Job], str] = MappingProxyType({
@@ -560,6 +561,7 @@ class AnchorTup(NamedTuple):
     kind: KindEnum = KindEnum.FIRST
     angle_offset: "None | float" = None
     dihedral: "None | float" = None
+    group_format: FormatEnum = FormatEnum.SMILES
 
 
 class AllignmentTup(NamedTuple):

--- a/docs/4_optional.rst
+++ b/docs/4_optional.rst
@@ -268,6 +268,7 @@ Core
 
         * :attr:`anchor.group <optional.ligand.anchor.group>`
         * :attr:`anchor.group_idx <optional.ligand.anchor.group_idx>`
+        * :attr:`anchor.group_format <optional.ligand.anchor.group_format>`
         * :attr:`anchor.remove <optional.ligand.anchor.remove>`
 
         .. note::
@@ -279,6 +280,7 @@ Core
                         anchor:
                             group: "[H]Cl"  # Remove HCl and attach at previous Cl position
                             group_idx: 1
+                            group_format: "SMILES"
                             remove: [0, 1]
 
 
@@ -647,6 +649,7 @@ Ligand
 
         * :attr:`anchor.group`
         * :attr:`anchor.group_idx`
+        * :attr:`anchor.group_format`
         * :attr:`anchor.remove`
         * :attr:`anchor.kind`
         * :attr:`anchor.angle_offset`
@@ -696,6 +699,39 @@ Ligand
 
         .. note::
             This argument has no value be default and must thus be provided by the user.
+
+
+    .. attribute:: optional.ligand.anchor.group_format
+
+        :Parameter:     * **Type** - :class:`str`
+                        * **Default value** – :data:`"SMILES"`
+
+        The format used for representing :attr:`anchor.group <optional.ligand.anchor.group>`.
+
+        Defaults to the SMILES format.
+        The supported formats (and matching RDKit parsers) are as following:
+
+        .. code-block:: python
+
+            >>> import rdkit.Chem
+
+            >>> FASTA      = rdkit.Chem.MolFromFASTA
+            >>> HELM       = rdkit.Chem.MolFromHELM
+            >>> INCHI      = rdkit.Chem.MolFromInchi
+            >>> MOL2       = rdkit.Chem.MolFromMol2Block
+            >>> MOL2_FILE  = rdkit.Chem.MolFromMol2File
+            >>> MOL        = rdkit.Chem.MolFromMolBlock
+            >>> MOL_FILE   = rdkit.Chem.MolFromMolFile
+            >>> PDB        = rdkit.Chem.MolFromPDBBlock
+            >>> PDB_FILE   = rdkit.Chem.MolFromPDBFile
+            >>> PNG        = rdkit.Chem.MolFromPNGString
+            >>> PNG_FILE   = rdkit.Chem.MolFromPNGFile
+            >>> SVG        = rdkit.Chem.MolFromRDKitSVG
+            >>> SEQUENCE   = rdkit.Chem.MolFromSequence
+            >>> SMARTS     = rdkit.Chem.MolFromSmarts
+            >>> SMILES     = rdkit.Chem.MolFromSmiles
+            >>> TPL        = rdkit.Chem.MolFromTPLBlock
+            >>> TPL_FILE   = rdkit.Chem.MolFromTPLFile
 
 
     .. attribute:: optional.ligand.anchor.remove

--- a/tests/test_ligand_anchoring.py
+++ b/tests/test_ligand_anchoring.py
@@ -1,5 +1,7 @@
 """Tests for :mod:`CAT.attachment.ligand_anchoring`."""
 
+# flake8: noqa: E501
+
 import os
 import sys
 import math
@@ -17,7 +19,7 @@ from scm.plams import from_smiles, Molecule
 from assertionlib import assertion
 from schema import SchemaError
 
-from CAT.utils import get_template, KindEnum, AnchorTup
+from CAT.utils import get_template, KindEnum, AnchorTup, FormatEnum
 from CAT.base import prep_input
 from CAT.attachment.ligand_anchoring import (
     get_functional_groups, _smiles_to_rdmol, find_substructure, init_ligand_anchoring
@@ -268,6 +270,9 @@ class TestInputParsing:
         out_of_bounds_remove=({"group": "OC", "group_idx": 0, "remove": 99}, IndexError),
         angle_unit=({"group": "OC", "group_idx": 0, "angle_offset": "0.5 bob"}, SchemaError),
         angle_invalid=({"group": "OC", "group_idx": 0, "angle_offset": "bob"}, SchemaError),
+        invalid_group=({"group": "OC", "group_idx": 0, "group": 1.0}, SchemaError),
+        invalid_group_format=({"group": "OC", "group_idx": 0, "group_format": 1}, SchemaError),
+        invalid_kind=({"group": "OC", "group_idx": 0, "kind": 1}, SchemaError),
     )
 
     @pytest.mark.parametrize("inp,exc_type", PARAM_RAISE.values(), ids=PARAM_RAISE.keys())
@@ -309,6 +314,9 @@ class TestInputParsing:
         kind_none={"group": "OCC", "group_idx": 0, "kind": None},
         kind_str={"group": "OCC", "group_idx": 0, "kind": "mean"},
         kind_enum={"group": "OCC", "group_idx": 0, "kind": KindEnum.MEAN_TRANSLATE},
+        group_format_none={"group": "OCC", "group_idx": 0, "group_format": None},
+        group_format_str={"group": "OCC", "group_idx": 0, "group_format": "SMARTS"},
+        group_format_enum={"group": "OCC", "group_idx": 0, "group_format": FormatEnum.SMARTS},
     )
     _PARAM_PASS2 = OrderedDict(
         idx_scalar=AnchorTup(None, group="OCC", group_idx=(0,)),
@@ -331,6 +339,9 @@ class TestInputParsing:
         kind_none=AnchorTup(None, group="OCC", group_idx=(0,), kind=KindEnum.FIRST),
         kind_str=AnchorTup(None, group="OCC", group_idx=(0,), kind=KindEnum.MEAN),
         kind_enum=AnchorTup(None, group="OCC", group_idx=(0,), kind=KindEnum.MEAN_TRANSLATE),
+        group_format_none=AnchorTup(None, group="OCC", group_idx=(0,), group_format=FormatEnum.SMILES),
+        group_format_str=AnchorTup(None, group="OCC", group_idx=(0,), group_format=FormatEnum.SMARTS),
+        group_format_enum=AnchorTup(None, group="OCC", group_idx=(0,), group_format=FormatEnum.SMARTS),
     )
     PARAM_PASS = OrderedDict({
         k: (v1, v2) for (k, v1), v2 in zip(_PARAM_PASS1.items(), _PARAM_PASS2.values())

--- a/tests/test_ligand_attach.py
+++ b/tests/test_ligand_attach.py
@@ -2,7 +2,7 @@
 
 import shutil
 from pathlib import Path
-from typing import Generator, NamedTuple, TYPE_CHECKING
+from typing import Generator, NamedTuple, TYPE_CHECKING, Any
 
 import yaml
 import pytest

--- a/tests/test_mol_str_parser.py
+++ b/tests/test_mol_str_parser.py
@@ -1,0 +1,46 @@
+import sys
+import textwrap
+
+import pytest
+from assertionlib import assertion
+from rdkit import Chem
+
+from CAT.utils import FormatEnum
+
+if sys.version_info >= (3, 7):
+    from builtins import dict as OrderedDict
+else:
+    from collections import OrderedDict
+
+PARAM = OrderedDict(
+    FASTA="MDSKGSSQ",
+    HELM="RNA1{R(U)P.R(T)P.R(G)P.R(C)P.R(A)}$$$$",
+    INCHI=r"InChI=1S/H2O/h1H2",
+    MOL=textwrap.dedent("""
+             RDKit          2D
+
+          1  0  0  0  0  0  0  0  0  0999 V2000
+            0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+        M  END
+    """),
+    PDB=textwrap.dedent("""\
+        HETATM    1  O1  UNL     1       0.000   0.000   0.000  1.00  0.00           O
+        END
+    """),
+    SMARTS=r"[N&H2&+0&D1:6]/[N&H0&+0&D2:5]=[c&H0&+0&D3:4](/[n:3]):[n&H1&+0&D2:2]:[c:1]",
+    SMILES="CCCCCO",
+)
+
+
+@pytest.mark.parametrize("kind,string", PARAM.items(), ids=PARAM)
+def test_str_parser(kind: str, string: str) -> None:
+    func = FormatEnum[kind].value
+    mol = func(string)
+    assertion.isinstance(mol, Chem.Mol)
+
+
+@pytest.mark.parametrize("kind", FormatEnum.__members__)
+def test_raise(kind: str) -> None:
+    func = FormatEnum[kind].value
+    with pytest.raises(ValueError):
+        func(r"bo%b")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,5 +91,5 @@ def test_restart_init() -> None:
 
 def test_get_formula() -> None:
     formula = get_formula(Molecule(PATH / "multi_ligand.pdb"))
-    matches = re.findall(f"([a-zA-Z]+)[0-9+]", formula)
+    matches = re.findall("([a-zA-Z]+)[0-9+]", formula)
     assertion.eq(matches, ["C", "Cd", "F", "H", "O", "Se"])


### PR DESCRIPTION
Adds the new `anchor.group_format` option, which can be used for specifying the format used for `anchor.group` (*e.g.* SMILES or SMARTS).

Examples
---------
``` yaml
optional:
    ligand:
        anchor:
            group: "[H]-[#8]"  # i.e. "[H]O"
            group_idx: 1
            group_format: "SMARTS"
```