### PR TITLE
BUG: Fix an issue wherein anchor-group-parsing could fail for mono-atomic anchors

### DIFF
--- a/CAT/data_handling/anchor_parsing.py
+++ b/CAT/data_handling/anchor_parsing.py
@@ -4,7 +4,7 @@ import re
 import operator
 from typing import Union, Tuple, Iterable, SupportsFloat
 
-from rdkit.Chem import Mol
+from rdkit import Chem
 from scm.plams import Units, PT
 from schema import Schema, Use, Optional
 from typing_extensions import TypedDict, SupportsIndex
@@ -114,18 +114,25 @@ def _parse_group(group: "str | SupportsIndex") -> str:
     try:
         atnum = operator.index(group)
     except TypeError:
-        if not isinstance(group, str):
-            raise TypeError("`group` expected a string or integer") from None
+        pass
     else:
         group = PT.get_symbol(atnum)
 
     # String parsing
-    if group in SQUARE_BRACKET_ATOMS:
-        return f"[{group}]"
+    if not isinstance(group, str):
+        raise TypeError("`group` expected a string or integer")
     elif group in DUMMY_SYMBOLS:
         return "*"
     else:
         return group
+
+
+def _symbol_to_rdmol(symbol: str) -> Chem.Mol:
+    """Helper function for converting atomic symbols to rdkit molecules."""
+    atom = Chem.Atom(PT.get_atomic_number(symbol))
+    mol = Chem.EditableMol(Chem.Mol())
+    mol.AddAtom(atom)
+    return mol.GetMol()
 
 
 anchor_schema = Schema({
@@ -138,11 +145,11 @@ anchor_schema = Schema({
     Optional("group_format", default=FormatEnum.SMILES): Use(_parse_group_format),
 })
 
-#: A collection of symbols used for different kinds of dummy atoms
+#: A collection of symbols used for different kinds of dummy atoms.
 DUMMY_SYMBOLS = frozenset(PT.dummysymbols)
 
-#: All atom types that have to be encapsulated in square brackets when parsing SMILES strings
-SQUARE_BRACKET_ATOMS = frozenset(
+#: All atom types that are not directly supported by the rdkit SMILES parser.
+INVALID_SMILES_ATOMS = frozenset(
     PT.symtonum.keys() - DUMMY_SYMBOLS - {'B', 'Br', 'C', 'Cl', 'F', 'I', 'N', 'O', 'P', 'S'}
 )
 
@@ -152,10 +159,10 @@ def parse_anchors(
         None,
         SupportsIndex,
         str,
-        Mol,
+        Chem.Mol,
         AnchorTup,
         _UnparsedAnchorDict,
-        "Iterable[str | SupportsIndex | Mol | AnchorTup | _UnparsedAnchorDict]",
+        "Iterable[str | SupportsIndex | Chem.Mol | AnchorTup | _UnparsedAnchorDict]",
     ] = None,
     split: bool = True,
     is_core: bool = False,
@@ -165,14 +172,14 @@ def parse_anchors(
         if is_core:
             raise TypeError("`anchor=None` is not supported for core anchors")
         patterns = get_functional_groups(None, split)
-    elif isinstance(patterns, (Mol, str, dict, AnchorTup, SupportsIndex)):
+    elif isinstance(patterns, (Chem.Mol, str, dict, AnchorTup, SupportsIndex)):
         patterns = [patterns]
 
     ret = []
-    for p in patterns:  # type: _UnparsedAnchorDict | str | Mol | SupportsIndex | AnchorTup
+    for p in patterns:  # type: _UnparsedAnchorDict | str | Chem.Mol | SupportsIndex | AnchorTup
         if isinstance(p, AnchorTup):
             ret.append(p)
-        elif isinstance(p, Mol):
+        elif isinstance(p, Chem.Mol):
             mol = p
             remove: "None | Tuple[int, ...]" = (
                 None if not split else (list(mol.GetAtoms())[-1].GetIdx(),)
@@ -186,7 +193,11 @@ def parse_anchors(
             angle_offset = kwargs["angle_offset"]
             dihedral = kwargs["dihedral"]
             group_parser = kwargs["group_format"].value
-            mol = group_parser(kwargs["group"])
+            group = kwargs["group"]
+            if group in INVALID_SMILES_ATOMS:
+                mol = _symbol_to_rdmol(group)
+            else:
+                mol = group_parser(group)
 
             # Dihedral and angle-offset options are not supported for core anchors
             if is_core:
@@ -225,7 +236,10 @@ def parse_anchors(
             ret.append(AnchorTup(**kwargs, mol=mol))
         else:
             group = _parse_group(p)
-            mol = _smiles_to_rdmol(group)
+            if group in INVALID_SMILES_ATOMS:
+                mol = _symbol_to_rdmol(group)
+            else:
+                mol = _smiles_to_rdmol(group)
             remove = None if not split else (list(mol.GetAtoms())[-1].GetIdx(),)
             ret.append(AnchorTup(mol=mol, group=group, remove=remove))
 

--- a/CAT/data_handling/anchor_parsing.py
+++ b/CAT/data_handling/anchor_parsing.py
@@ -170,13 +170,6 @@ def parse_anchors(
 
     ret = []
     for p in patterns:  # type: _UnparsedAnchorDict | str | Mol | SupportsIndex | AnchorTup
-        try:
-            atnum = operator.index(p)  # Check for atomic symbols
-        except TypeError:
-            pass
-        else:
-            p = PT.get_symbol(atnum)
-
         if isinstance(p, AnchorTup):
             ret.append(p)
         elif isinstance(p, Mol):

--- a/CAT/mol_utils.py
+++ b/CAT/mol_utils.py
@@ -39,12 +39,9 @@ import scm.plams.interfaces.molecule.rdkit as molkit
 from rdkit import Chem
 from rdkit.Chem import rdMolTransforms
 
-__all__ = ['adf_connectivity', 'fix_h', 'fix_carboxyl']
+from ._mol_str_parser import FormatEnum
 
-try:
-    SANITIZE: int = Chem.SanitizeFlags.SANITIZE_ALL ^ Chem.SanitizeFlags.SANITIZE_ADJUSTHS
-except TypeError:  # This prevents Sphinx from raising a TypeError when rdkit is mocked
-    SANITIZE = 0
+__all__ = ['adf_connectivity', 'fix_h', 'fix_carboxyl']
 
 
 @add_to_class(Molecule)
@@ -311,16 +308,7 @@ def adf_connectivity(mol: Molecule) -> List[str]:
     return bonds
 
 
-def _smiles_to_rdmol(smiles: str) -> Chem.Mol:
-    """Convert a SMILES string into an rdkit Mol; supports explicit hydrogens."""
-    # RDKit tends to remove explicit hydrogens if SANITIZE_ADJUSTHS is enabled
-    try:
-        mol = Chem.MolFromSmiles(smiles, sanitize=False)
-        Chem.rdmolops.SanitizeMol(mol, sanitizeOps=SANITIZE)
-    except Exception as ex:
-        raise ex.__class__(f'Failed to parse the following SMILES string: {repr(smiles)}\n\n{ex}')
-    return mol
-
+_smiles_to_rdmol = FormatEnum.SMILES.value
 
 #: A carboxylate
 _CARBOXYLATE: Chem.Mol = _smiles_to_rdmol('[O-]C(C)=O')


### PR DESCRIPTION
Manually construct the reference group-molecules if mono-atomic anchors are encountered that lack RDKit SMILES support, _e.g._ `anchor.group: "Rb"`.