### PR TITLE
BLD: Allow installing `CAT` without the use of conda

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,13 +19,16 @@ jobs:
                 os: [ubuntu-latest, macos-latest]
                 version: ["3.6", "3.7", "3.8", "3.9"]
                 special: [""]
+                conda: [false]
                 include:
                     -   os: ubuntu-latest
                         special: "; pre-release"
-                        version: "3.9"
+                        version: "3.10"
+                        conda: false
                     -   os: ubuntu-latest
                         special: "; minimum version"
                         version: "3.6"
+                        conda: true
         steps:
             -   name: Cancel Previous Runs
                 uses: styfle/cancel-workflow-action@0.9.1
@@ -35,45 +38,66 @@ jobs:
             -   uses: actions/checkout@v2
 
             -   name: Setup Conda
+                if: matrix.conda == true
                 uses: s-weigand/setup-conda@v1
                 with:
                     update-conda: false
+
+            -   name: Set up Python
+                if: matrix.conda == false
+                uses: actions/setup-python@v2
+                with:
+                    python-version: ${{ matrix.version }}
 
             -   name: Install dependencies
                 run: |
                     case "${{ matrix.special }}" in
                         "; minimum version")
-                            conda create -n test -c conda-forge python=${{ matrix.version }} rdkit==2018.03.1 numpy=1.15.0 pandas=0.23.0 h5py=2.7.0 scipy=0.19.1 contextlib2==0.6.0 typing-extensions==3.7.4.2 pytest==5.4.0 pyyaml=5.1.0 pytest-cov pytest-mock
+                            conda create -n test -c conda-forge python=${{ matrix.version }} rdkit==2018.03.1 numpy=1.15.0 pandas=0.23.0 h5py=2.7.0 scipy=0.19.1 contextlib2==0.6.0 typing-extensions==3.7.4.3 pytest==5.4.0 pyyaml=5.1.0 pytest-cov pytest-mock
                             source $CONDA/bin/activate test
                             pip install schema==0.7.2 Nano-Utils==0.4.3 AssertionLib==2.2.3 plams==1.5.1 qmflows==0.11.0
+                            pip install -e . --no-dependencies
                             ;;
-                        *)
-                            conda create -n test -c conda-forge python=${{ matrix.version }} "rdkit>=2021.03.4"
-                            source $CONDA/bin/activate test
-                            ;;
-                    esac
-
-                    case "${{ matrix.special }}" in
                         "; pre-release")
                             pip install -e .[test] --pre --upgrade --force-reinstall
                             pip install git+https://github.com/SCM-NV/qmflows@master --upgrade
                             pip install git+https://github.com/SCM-NV/PLAMS@master --upgrade
                             ;;
                         *)
-                            pip install -e .[test] ;;
+                            pip install -e .[test]
+                            ;;
                     esac
 
-            -   name: Conda info
+            -   name: Info Conda
+                if: matrix.conda == true
                 run: |
                     source $CONDA/bin/activate test
                     conda info
 
-            -   name: Installed packages
-                run: conda list -n test
+            -   name: Info Python
+                run: |
+                    case "${{ matrix.conda }}" in
+                        true)
+                            source $CONDA/bin/activate test ;;
+                    esac
+                    which python
+                    python --version
+
+            -   name: Info installed packages
+                run: |
+                    case "${{ matrix.conda }}" in
+                        true)
+                            conda list -n test ;;
+                        *)
+                            pip list ;;
+                    esac
 
             -   name: Run tests
                 run: |
-                    source $CONDA/bin/activate test
+                    case "${{ matrix.conda }}" in
+                        true)
+                            source $CONDA/bin/activate test ;;
+                    esac
                     pytest -m "not slow"
 
             -   name: Run codecov

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest]
-                version: ["3.6", "3.7", "3.8", "3.9"]
+                version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
                 special: [""]
                 conda: [false]
                 include:

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@
    :target: https://docs.python.org/3.8/
 .. image:: https://img.shields.io/badge/python-3.9-blue.svg
    :target: https://docs.python.org/3.9/
+.. image:: https://img.shields.io/badge/python-3.10-blue.svg
+   :target: https://docs.python.org/3.10/
 
 ###############################
 Compound Attachment Tool 0.10.2

--- a/README.rst
+++ b/README.rst
@@ -25,42 +25,19 @@ Compound Attachment Tool 0.10.2
 **CAT** is a collection of tools designed for the construction of various chemical compounds.
 Further information is provided in the documentation_.
 
-Installation
-============
-
-- Download miniconda for python3: miniconda_ (also you can install the complete anaconda_ version).
-
-- Install according to: installConda_.
-
-- Create a new virtual environment, for python 3.7, using the following commands:
-
-  - ``conda create --name CAT python``
-
-- The virtual environment can be enabled and disabled by, respectively, typing:
-
-  - Enable: ``conda activate CAT``
-
-  - Disable: ``conda deactivate``
-
-
-.. _dependecies:
-
-Dependencies installation
--------------------------
-
-Using the conda environment the following packages should be installed:
-
-- rdkit_ : ``conda install -y --name CAT --channel conda-forge rdkit``
-
-.. _installation:
-
 Package installation
 --------------------
-Finally, install **CAT** using pip:
+**CAT** can be installed via pip as following:
 
 - **CAT**: ``pip install nlesc-CAT --upgrade``
 
-Now you are ready to use **CAT**.
+Note that, while not strictly necessary, it is recommended to first create a conda environment:
+
+- Download and install miniconda for python3: miniconda_ (also you can install the complete anaconda_ version).
+
+- Create a new virtual environment:  ``conda create --name CAT python``
+
+- Activate the environment:: ``conda activate CAT``
 
 Input files
 ============

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import re
-import sys
 
 from setuptools import setup
 
@@ -15,47 +13,6 @@ with open(os.path.join(here, 'CAT', '__version__.py')) as f:
 
 with open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
-
-docs_require = [
-    'sphinx>=2.4',
-    'sphinx_rtd_theme',
-    'data-CAT>=0.7.0',
-    'nano-CAT>=0.7.1',
-    'auto-FOX>=0.10.0',
-]
-
-tests_require = [
-    'pytest>=5.4.0',
-    'pytest-cov',
-    'pytest-mock',
-    'h5py>=2.7.0',
-]
-if sys.version_info >= (3, 7):
-    tests_require += docs_require
-
-
-def _validate_rdkit():
-    # Check if rdkit is manually installed (as it is not available via pypi)
-    try:
-        import rdkit
-    except ModuleNotFoundError:
-        print("`CAT` requires the `rdkit` package: https://anaconda.org/conda-forge/rdkit",
-              file=sys.stderr)
-        return
-
-    version = getattr(rdkit, "__version__", "unknown")
-    match = re.match(r"([0-9]+)\.([0-9]+)\.([0-9]+)", version)
-    if match is None:
-        print("failed to parse the `rdkit` version: {}".format(version), file=sys.stderr)
-        return
-
-    version_tup = tuple(int(i) for i in match.groups())
-    if version_tup < (2018, 3, 1):
-        print("`CAT` requires `rdkit` >= 2018.03.1, observed version: {}".format(version), file=sys.stderr)
-        sys.exit(1)
-
-
-_validate_rdkit()
 
 setup(
     name='nlesc-CAT',
@@ -140,13 +97,29 @@ setup(
         'contextlib2>=0.6.0; python_version=="3.6"',
         'typing-extensions>=3.7.4.3',
         'qmflows>=0.11.0',
+        'rdkit-pypi>=2018.03.1',
     ],
     setup_requires=[
         'pytest-runner',
     ],
-    tests_require=tests_require,
     extras_require={
-        'test': tests_require,
-        'doc': docs_require,
+        'test': [
+            'pytest>=5.4.0',
+            'pytest-cov',
+            'pytest-mock',
+            'h5py>=2.7.0',
+            'sphinx>=2.4; python_version>="3.7"',
+            'sphinx_rtd_theme; python_version>="3.7"',
+            'data-CAT>=0.7.0; python_version>="3.7"',
+            'nano-CAT>=0.7.1; python_version>="3.7"',
+            'auto-FOX>=0.10.0; python_version>="3.7"',
+        ],
+        'doc': [
+            'sphinx>=2.4',
+            'sphinx_rtd_theme',
+            'data-CAT>=0.7.0',
+            'nano-CAT>=0.7.1',
+            'auto-FOX>=0.10.0',
+        ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'python-3-7',
         'python-3-8',
         'python-3-9',
+        'python-3-10',
         'automation',
         'scientific-workflows'
     ],
@@ -80,6 +81,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: Chemistry',
         'Typing :: Typed',
     ],


### PR DESCRIPTION
Automatically use install `rdkit` via [pypi](https://pypi.org/project/rdkit-pypi/) when it's not pre-installed via conda.