### PR TITLE
BUG: Fix the BDE `core_atom` and `lig_count` keys not being optional

### DIFF
--- a/CAT/data_handling/validate_input.py
+++ b/CAT/data_handling/validate_input.py
@@ -176,6 +176,11 @@ def validate_input(s: Settings, validate_only: bool = True) -> None:
             s.optional.qd.optimize = qd_opt_schema.validate(s.optional.qd.optimize)
         if s.optional.qd.dissociate:
             bde_dict = bde_schema.validate(s.optional.qd.dissociate)
+            if (
+                (bde_dict["core_atom"] is bde_dict["lig_count"] is None) or
+                (bde_dict["core_atom"] is not None and bde_dict["lig_count"] is not None)
+            ):
+                raise ValueError("One of `core_atom` and `lig_count` must be specified")
             s.optional.qd.dissociate = parse_qmflows_keywords(bde_dict)
         if s.optional.qd.activation_strain:
             s.optional.qd.activation_strain = asa_schema.validate(s.optional.qd.activation_strain)

--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -648,17 +648,19 @@ bde_schema: Schema = Schema({
         bool,
 
     # Atom type of the to-be dissociated core atom
-    'core_atom':
-        And(
-            Or(And(val_int, Use(int)), str), Use(validate_core_atom),
+    Optional_('core_atom', default=None):
+        Or(
+            None,
+            And(Or(And(val_int, Use(int)), str), Use(validate_core_atom)),
             error=('optional.qd.dissociate.core_atom expects a SMILES string, '
                    'atomic number (int) or atomic symbol (str)')
         ),
 
-    'lig_count':  # The number of ligands per core_atom
-        And(
-            val_int, lambda n: int(n) >= 0, Use(int),
-            error='optional.qd.dissociate.lig_count expects an integer larger than or equal to 0'
+    Optional_('lig_count', default=None):  # The number of ligands per core_atom
+        Or(
+            None,
+            And(val_int, lambda n: int(n) >= 0, Use(int)),
+            error='optional.qd.dissociate.lig_count expects an integer larger than or equal to 0',
         ),
 
     Optional_('keep_files', default=True):  # Delete files after the calculations are finished


### PR DESCRIPTION
It should be possible to specify either the BDE `core_atom` or `lig_count` options, while previously the `core_atom` was (incorrectly) considered mandatory.