### PR TITLE
ENH: Add the ``qd.dissociate.qd_opt`` keyword

### DIFF
--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -775,6 +775,9 @@ bde_schema: Schema = Schema({
         ),
 
     Optional_("xyn_pre_opt", default=True): bool,
+
+    Optional_("qd_opt", default=False): bool,
+
 })
 
 #: Schema for validating the ``['optional']['qd']['optimize']`` block.

--- a/CAT/workflows/workflow_yaml.yaml
+++ b/CAT/workflows/workflow_yaml.yaml
@@ -108,6 +108,7 @@ bde:
         job2: [optional, qd, dissociate, job2]
         s2: [optional, qd, dissociate, s2]
         xyn_pre_opt: [optional, qd, dissociate, xyn_pre_opt]
+        qd_opt: [optional, qd, dissociate, qd_opt]
 
         core_atom: [optional, qd, dissociate, core_atom]
         lig_count: [optional, qd, dissociate, lig_count]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 0.10.4
 ******
-* *placeholder*.
+* Added the ``qd.dissociate.qd_opt`` keyword.
+* Fix thermochemical properties not properly being set to ``nan`` for crashed jobs.
 
 
 0.10.3

--- a/docs/5_bde.rst
+++ b/docs/5_bde.rst
@@ -214,6 +214,15 @@ Arguments
             are marked as ``"vertice"``, the ones with ``8`` neighbours are marked as ``"edge"``
             and the ones with ``10`` neighbours as ``"face"``.
 
+
+    .. attribute:: optional.qd.dissociate.qd_opt
+
+        :Parameter:     * **Type** - :class:`bool`
+                        * **Default value** – ``False``
+
+        Whether to optimize the quantum dot and |XYn| -dissociated quantum dot.
+
+
 |
 
 Arguments - Job Customization

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -390,6 +390,7 @@ def test_bde_schema() -> None:
 
         'keep_files': True,
         'xyn_pre_opt': True,
+        'qd_opt': False,
         'job1': AMSJob,
         's1': _bde_s1_default,
         'job2': None,


### PR DESCRIPTION
Adds ``qd.dissociate.qd_opt`` keyword, which is used for optimizing the QD and XYn-dissociated QD in the dissociation workflow.