### PR TITLE
ENH: Allow multiple values for the bulkiness latice spacing

### DIFF
--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -561,6 +561,14 @@ qd_schema: Schema = Schema({
         ),
 })
 
+
+def _to_float_array(obj: Any) -> np.ndarray:
+    ar = np.asarray(obj)
+    ret = ar.astype(np.float64, casting="same_kind")
+    assert ret.ndim <= 1
+    return ret
+
+
 #: Schema for validating the ``['optional']['qd']['bulkiness']`` block.
 bulkiness_schema = Schema({
     Optional_('h_lim', default=10.0): Or(
@@ -570,7 +578,7 @@ bulkiness_schema = Schema({
     ),
 
     Optional_('d', default='auto'): Or(
-        And(val_float, lambda n: float(n) > 0, Use(float)),
+        Use(_to_float_array),
         None,
         And(str, lambda n: n.lower() == 'auto', Use(str.lower)),
         error='optional.qd.bulkiness.d expects a positive float, None or "auto"'

--- a/docs/4_optional.rst
+++ b/docs/4_optional.rst
@@ -1009,7 +1009,7 @@ QD
 
     .. attribute:: optional.qd.bulkiness.d
 
-        :Parameter:     * **Type** - :class:`float`, :data:`None` or ``"auto"``
+        :Parameter:     * **Type** - :class:`float`/:class:`list[float] <list>`, :data:`None` or ``"auto"``
                         * **Default value** – ``"auto"``
 
         Default value of the :math:`d` parameter in :attr:`~optional.qd.bulkiness`.
@@ -1017,6 +1017,7 @@ QD
         Set to ``"auto"`` to automatically infer this parameters value based on the mean
         nearest-neighbor distance among the core anchor atoms.
         Set to :data:`None` to disable the :math:`d`-based cutoff.
+        Supplying multiple floats will compute the bulkiness for all specified values.
 
 
     .. attribute:: optional.qd.activation_strain


### PR DESCRIPTION
Part of https://github.com/nlesc-nano/nano-CAT/issues/115.

Allows the `optional.qd.bulkiness.d` option to take both floats as well as list of floats, the latter computing the bulkiness for a range of different lattice spacing values.