### PR TITLE
ENH: Add the option to disable ligand canonicalization

### DIFF
--- a/CAT/data_handling/mol_import.py
+++ b/CAT/data_handling/mol_import.py
@@ -125,7 +125,7 @@ def read_mol_xyz(mol_dict: Settings) -> Optional[Molecule]:
         mol = Molecule(mol_dict.mol, inputformat='xyz')
         if mol_dict.guess_bonds and not mol_dict.is_qd:
             mol.guess_bonds()
-        if not mol_dict.is_core:
+        if mol_dict.canonicalize:
             canonicalize_mol(mol)
         return mol
     except Exception as ex:
@@ -138,7 +138,7 @@ def read_mol_pdb(mol_dict: Settings) -> Optional[Molecule]:
         mol = molkit.readpdb(mol_dict.mol)
         if mol_dict.guess_bonds and not mol_dict.is_qd:
             mol.guess_bonds()
-        if not mol_dict.is_core:
+        if mol_dict.canonicalize:
             canonicalize_mol(mol)
         return mol
     except Exception as ex:
@@ -151,7 +151,7 @@ def read_mol_mol(mol_dict: Settings) -> Optional[Molecule]:
         mol = molkit.from_rdmol(Chem.MolFromMolFile(mol_dict.mol, removeHs=False))
         if mol_dict.guess_bonds and not mol_dict.is_qd:
             mol.guess_bonds()
-        if not mol_dict.is_core:
+        if mol_dict.canonicalize:
             canonicalize_mol(mol)
         return mol
     except Exception as ex:
@@ -197,7 +197,7 @@ def read_mol_plams(mol_dict: Settings) -> Optional[Molecule]:
         mol = mol_dict.mol
         if mol_dict.guess_bonds and not mol_dict.is_qd:
             mol.guess_bonds()
-        if not mol_dict.is_core:
+        if mol_dict.canonicalize:
             canonicalize_mol(mol)
         return mol
     except Exception as ex:
@@ -210,7 +210,7 @@ def read_mol_rdkit(mol_dict: Settings) -> Optional[Molecule]:
         mol = molkit.from_rdmol(mol_dict.mol)
         if mol_dict.guess_bonds and not mol_dict.is_qd:
             mol.guess_bonds()
-        if not mol_dict.is_core:
+        if mol_dict.canonicalize:
             canonicalize_mol(mol)
         return mol
     except Exception as ex:

--- a/CAT/data_handling/validate_mol.py
+++ b/CAT/data_handling/validate_mol.py
@@ -153,13 +153,19 @@ def validate_mol(args: Sequence[Union[Any, Settings]],
     for i, dict_ in enumerate(args):
         if not isinstance(dict_, dict):  # No optional arguments provided
             mol = dict_
-            mol_dict = Settings({'path': _path, 'is_core': is_core, 'is_qd': is_qd})
+            mol_dict = Settings({
+                'path': _path,
+                'is_core': is_core,
+                'is_qd': is_qd,
+                'canonicalize': not is_core,
+            })
         else:  # Optional arguments have been provided: parse and validate them
             if dict_.get('parsed'):
                 continue
             mol, mol_dict = next(iter(dict_.items()))
             mol_dict.setdefault('is_core', is_core)
             mol_dict.setdefault('is_qd', is_qd)
+            mol_dict.setdefault('canonicalize', not mol_dict.is_core)
             mol_dict = mol_schema.validate(mol_dict)
             mol_dict.setdefault('path', _path)
 

--- a/CAT/data_handling/validation_schemas.py
+++ b/CAT/data_handling/validation_schemas.py
@@ -238,6 +238,9 @@ mol_schema: Schema = Schema({
     Optional_('is_core'):
         And(bool, error=".is_core expects a boolean"),
 
+    Optional_('canonicalize'):
+        And(bool, error=".canonicalize expects a boolean"),
+
     Optional_('is_qd'):
         And(bool, error=".is_qd expects a boolean"),
 

--- a/docs/3_input_core_ligand.rst
+++ b/docs/3_input_core_ligand.rst
@@ -71,6 +71,15 @@ Optional arguments
     Relevant for .txt and .csv files.
     Numbering starts from 0.
 
+
+.. attribute:: .canonicalize
+
+    :Parameter:     * **Type** - :class:`bool`
+                    * **Default value** – ``False`` for cores and ``True`` for ligands
+
+    Whether the atom order of the passed molecules should be canonicalized.
+
+
 .. attribute:: .indices
 
     :Parameter:     * **Type** - :class:`int` or :class:`tuple` [:class:`int`]

--- a/tests/test_mol_import.py
+++ b/tests/test_mol_import.py
@@ -24,7 +24,7 @@ canonicalize_mol(REF_MOL)
 def test_read_mol_xyz() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_xyz`."""
     xyz = join(PATH, 'Methanol.xyz')
-    mol_dict = Settings({'mol': xyz, 'guess_bonds': True})
+    mol_dict = Settings({'mol': xyz, 'guess_bonds': True, 'canonicalize': True})
     mol = read_mol_xyz(mol_dict)
 
     assertion.isinstance(mol, Molecule)
@@ -35,7 +35,7 @@ def test_read_mol_xyz() -> None:
 def test_read_mol_pdb() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_pdb`."""
     pdb = join(PATH, 'Methanol.pdb')
-    mol_dict = Settings({'mol': pdb, 'guess_bonds': False})
+    mol_dict = Settings({'mol': pdb, 'guess_bonds': False, 'canonicalize': True})
     mol = read_mol_pdb(mol_dict)
 
     assertion.isinstance(mol, Molecule)
@@ -46,7 +46,7 @@ def test_read_mol_pdb() -> None:
 def test_read_mol_mol() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_mol`."""
     mol_file = join(PATH, 'Methanol.mol')
-    mol_dict = Settings({'mol': mol_file, 'guess_bonds': False})
+    mol_dict = Settings({'mol': mol_file, 'guess_bonds': False, 'canonicalize': True})
     mol = read_mol_mol(mol_dict)
 
     assertion.isinstance(mol, Molecule)
@@ -57,7 +57,7 @@ def test_read_mol_mol() -> None:
 def test_read_mol_smiles() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_smiles`."""
     smiles = 'CO'
-    mol_dict = Settings({'mol': smiles, 'guess_bonds': False})
+    mol_dict = Settings({'mol': smiles, 'guess_bonds': False, 'canonicalize': True})
     mol = read_mol_smiles(mol_dict)
 
     assertion.isinstance(mol, Molecule)
@@ -68,7 +68,7 @@ def test_read_mol_plams() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_smiles`."""
     mol = REF_MOL.copy()
     random.shuffle(mol.atoms)
-    mol_dict = Settings({'mol': mol, 'guess_bonds': False})
+    mol_dict = Settings({'mol': mol, 'guess_bonds': False, 'canonicalize': True})
     mol = read_mol_plams(mol_dict)
 
     assertion.isinstance(mol, Molecule)
@@ -81,7 +81,7 @@ def test_read_mol_rdkit() -> None:
     mol = REF_MOL.copy()
     random.shuffle(mol.atoms)
     rdmol = molkit.to_rdmol(mol)
-    mol_dict = Settings({'mol': rdmol, 'guess_bonds': False})
+    mol_dict = Settings({'mol': rdmol, 'guess_bonds': False, 'canonicalize': True})
     mol = read_mol_rdkit(mol_dict)
 
     assertion.isinstance(mol, Molecule)
@@ -91,7 +91,13 @@ def test_read_mol_rdkit() -> None:
 
 def test_read_mol_folder() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_folder`."""
-    mol_dict = Settings({'mol': PATH, 'path': PATH, 'guess_bonds': True, 'is_core': False})
+    mol_dict = Settings({
+        'mol': PATH,
+        'path': PATH,
+        'guess_bonds': True,
+        'is_core': False,
+        'canonicalize': True,
+    })
     _mol_list = read_mol_folder(mol_dict)
     mol_list = [mol for mol in _mol_list if get_formula(mol) == 'C1H4O1']
 
@@ -104,7 +110,13 @@ def test_read_mol_folder() -> None:
 def test_read_mol_txt() -> None:
     """Test :func:`CAT.data_handling.validate_input.read_mol_txt`."""
     txt = join(PATH, 'Methanol.txt')
-    mol_dict = Settings({'mol': txt, 'path': PATH, 'guess_bonds': True, 'is_core': False})
+    mol_dict = Settings({
+        'mol': txt,
+        'path': PATH,
+        'guess_bonds': True,
+        'is_core': False,
+        'canonicalize': True,
+    })
     mol_list = read_mol_txt(mol_dict)
 
     for mol in mol_list[:-1]:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -11,7 +11,6 @@ from scm.plams import AMSJob, ADFJob, Settings, CRSJob
 from assertionlib import assertion
 
 from CAT.utils import get_template, AllignmentTup, AllignmentEnum
-from CAT.data_handling.str_to_func import str_to_func
 from CAT.data_handling.validation_schemas import (
     mol_schema, core_schema, ligand_schema, qd_schema, database_schema,
     mongodb_schema, bde_schema, qd_opt_schema, crs_schema, subset_schema
@@ -503,8 +502,7 @@ def test_subset_schema() -> None:
     }
 
     subset_dict = subset_schema.validate(subset_dict)
-    weight = subset_dict.pop('weight')
-
+    del subset_dict["weight"]
     assertion.eq(subset_dict, ref)
 
     subset_dict['p'] = 'bob'  # Exception: incorrect type

--- a/tests/test_validate_mol.py
+++ b/tests/test_validate_mol.py
@@ -78,39 +78,51 @@ def test_validate_mol() -> None:
     ]
 
     ref1 = [
-        {'path': PATH,
-         'is_core': True,
-         'is_qd': False,
-         'mol': join(PATH, 'Methanol.xyz'),
-         'type': 'xyz',
-         'name': 'Methanol',
-         'parsed': True},
-        {'path': PATH,
-         'is_core': True,
-         'is_qd': False,
-         'mol': join(PATH, 'Ethylene.xyz'),
-         'type': 'xyz',
-         'name': 'Ethylene',
-         'parsed': True}
+        {
+            'path': PATH,
+            'is_core': True,
+            'is_qd': False,
+            'mol': join(PATH, 'Methanol.xyz'),
+            'type': 'xyz',
+            'name': 'Methanol',
+            'parsed': True,
+            'canonicalize': False,
+        },
+        {
+            'path': PATH,
+            'is_core': True,
+            'is_qd': False,
+            'mol': join(PATH, 'Ethylene.xyz'),
+            'type': 'xyz',
+            'name': 'Ethylene',
+            'parsed': True,
+            'canonicalize': False,
+        },
     ]
 
     ref2 = [
-        {'guess_bonds': False,
-         'is_core': False,
-         'is_qd': False,
-         'path': PATH,
-         'mol': join(PATH, 'Acetate.xyz'),
-         'type': 'xyz',
-         'name': 'Acetate',
-         'parsed': True},
-        {'guess_bonds': False,
-         'is_core': False,
-         'is_qd': False,
-         'path': PATH,
-         'mol': join(PATH, 'Methanol_rotate.xyz'),
-         'type': 'xyz',
-         'name': 'Methanol_rotate',
-         'parsed': True}
+        {
+            'guess_bonds': False,
+            'is_core': False,
+            'is_qd': False,
+            'path': PATH,
+            'mol': join(PATH, 'Acetate.xyz'),
+            'type': 'xyz',
+            'name': 'Acetate',
+            'parsed': True,
+            'canonicalize': True,
+        },
+        {
+            'guess_bonds': False,
+            'is_core': False,
+            'is_qd': False,
+            'path': PATH,
+            'mol': join(PATH, 'Methanol_rotate.xyz'),
+            'type': 'xyz',
+            'name': 'Methanol_rotate',
+            'parsed': True,
+            'canonicalize': True,
+        }
     ]
 
     validate_mol(args1, 'input_cores', PATH)


### PR DESCRIPTION
Closes https://github.com/nlesc-nano/CAT/issues/262

Adds the option to explicitly enable or disable the canonicalization of input molecules.

Examples
----------
``` yaml
input_cores:
    - Cd68Se55.xyz

input_ligands:
    - OC(C)=O:
        canonicalize: True
    - OC(CC)=O:
        canonicalize: False
```