### PR TITLE
MAINT: Get rid `pkg_resources`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,15 +7,23 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-    configuration: docs/conf.py
+  configuration: docs/conf.py
+
+# Configuration for the documentation build process.
+# This allows you to specify the base Read the Docs image used to build the documentation,
+# and control the versions of several tools: Python, Node.js, Rust, and Go.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 # Optionally build your docs in additional formats such as PDF
 formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-    install:
-        - method: pip
-          path: .
-          extra_requirements:
-            - doc
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/CAT/utils.py
+++ b/CAT/utils.py
@@ -35,7 +35,6 @@ import operator
 import threading
 import functools
 import pprint
-import pkg_resources as pkg
 from types import MappingProxyType, TracebackType
 from shutil import rmtree
 from logging import Logger
@@ -60,6 +59,7 @@ from scm.plams import (
     from_smiles, AMSJob, ADFJob, Cp2kJob, DiracJob, GamessJob, CRSJob
 )
 
+from . import __file__ as _cat_file
 from .logger import logger
 from .mol_utils import to_atnum
 from .gen_job_manager import GenJobManager
@@ -140,8 +140,9 @@ def get_template(template_name: str, from_cat_data: bool = True) -> Settings:
     """Grab a yaml template and return it as Settings object."""
     if from_cat_data:
         path = join('data/templates', template_name)
-        xs = pkg.resource_string('CAT', path)
-        return Settings(yaml.load(xs.decode(), Loader=yaml.FullLoader))
+        xs = os.path.dirname(_cat_file)
+        with open(os.path.join(xs, path), "r", encoding="utf8") as f:
+            return Settings(yaml.load(f.read(), Loader=yaml.FullLoader))
     with open(template_name, 'r') as file:
         return Settings(yaml.load(file, Loader=yaml.FullLoader))
 


### PR DESCRIPTION
CC @RobertaPascazio 

Get rid of `pkg_resources` due to a number of deprecations and recent issues with running it on one of the clusters.